### PR TITLE
Fix + Test: Update copyright & Test CI/CD

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
                 <a href="/request-key">Request API Key</a>
                 <a href="/admin-login">Admin Login</a>
             </div>
-            <p>&copy; 2024 Sugar-AI. Licensed under GNU GPL v3.</p>
+            <p>&copy; 2025 Sugar-AI. Licensed under GNU GPL v3.</p>
         </div>
     </footer>
     {% endblock %}


### PR DESCRIPTION
- Update copyright year in the website footer from 2024 - 2025.
- Making this change so we can also test out if the new CI/CD pipeline works.
