### PR TITLE
fix: add missing huggingface_hub dependency and pin transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-transformers>=4.45.2
+transformers>=4.45.2,<4.47.0
+huggingface_hub>=0.26.5
 torch>=1.12.1
 accelerate>=0.26.0
 faiss-cpu


### PR DESCRIPTION
## Problem
When installing dependencies fresh using `pip install -r requirements.txt`, 
two issues occur:

1. `huggingface_hub` is not listed in requirements.txt but is a required 
   dependency of `transformers`. This causes an ImportError on fresh installs.

2. `transformers>=4.45.2` has no upper bound, which installs versions that 
   conflict with `huggingface_hub`, breaking the application startup.

## Fix
- Added `huggingface_hub>=0.26.5` explicitly to requirements.txt
- Pinned transformers to `<4.47.0` to prevent incompatible version installs

## How to reproduce the bug
1. Clone the repo fresh
2. Run `pip install -r requirements.txt`
3. Run `python main.py`
4. See ImportError: cannot import name 'is_offline_mode' from 'huggingface_hub'

## Testing
After this fix, `python main.py` starts successfully.