### PR TITLE
fix: set secure default for MODEL_CHANGE_PASSWORD

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,7 +12,7 @@ load_dotenv()
 class Settings(BaseSettings):
     """Application settings loaded from environment variables"""
     API_KEYS: Dict[str, Dict[str, Any]] = json.loads(os.getenv("API_KEYS", "{}"))
-    MODEL_CHANGE_PASSWORD: str = os.getenv("MODEL_CHANGE_PASSWORD", "")
+    MODEL_CHANGE_PASSWORD: str = os.getenv("MODEL_CHANGE_PASSWORD", "changeme")
     DEFAULT_MODEL: str = os.getenv("DEFAULT_MODEL", "Qwen/Qwen2-1.5B-Instruct")
     DOC_PATHS: List[str] = json.loads(os.getenv("DOC_PATHS", '["./docs/Pygame Documentation.pdf", "./docs/Python GTK+3 Documentation.pdf", "./docs/Sugar Toolkit Documentation.pdf"]'))
     MAX_DAILY_REQUESTS: int = int(os.getenv("MAX_DAILY_REQUESTS", 100))


### PR DESCRIPTION
## Problem
`MODEL_CHANGE_PASSWORD` in `app/config.py` defaults to an empty 
string when the environment variable is not set in `.env`.

The `/change-model` endpoint in `app/routes/api.py` checks:
```python
if password != settings.MODEL_CHANGE_PASSWORD:
    raise HTTPException(status_code=403, detail="Invalid model change password")
```

This means on a fresh install without a `.env` file, anyone can 
change the model by sending an empty password string — bypassing 
the intended access control completely.

## Fix
Changed the default value from `""` to `"changeme"` so the 
endpoint is protected even without explicit configuration.

Users should still set a strong `MODEL_CHANGE_PASSWORD` in 
their `.env` file for production use.

## Testing
Verified that the `/change-model` endpoint correctly rejects 
requests with wrong passwords returning `"Invalid model change 
password"`.

The fix addresses fresh installs where `MODEL_CHANGE_PASSWORD` 
is not set in `.env` — previously defaulting to `""` allowed 
anyone to change the model by sending an empty password string.