### PR TITLE
fix: use max_new_tokens instead of max_length in set_model

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -98,7 +98,7 @@ class RAGAgent:
         self.model = pipeline(
             "text-generation",
             model=model,
-            max_length=1024,
+            max_new_tokens=1024,
             truncation=True,
             torch_dtype=torch.float16
         )


### PR DESCRIPTION
## Problem
`set_model()` in `app/ai.py` uses `max_length=1024` when 
initializing the pipeline, while `__init__()` correctly uses 
`max_new_tokens=1024`.

These two parameters behave differently:
- `max_length` limits the total tokens including the input prompt
- `max_new_tokens` limits only the generated output tokens

This inconsistency means that after calling `/change-model`, 
responses may be significantly shorter than expected because 
input tokens consume part of the `max_length` budget.

This was missed in commit 659ff99 which updated `__init__` 
from `max_length` to `max_new_tokens` but did not update 
`set_model`.

## Fix
Changed `max_length=1024` to `max_new_tokens=1024` in 
`set_model()` to match the behavior in `__init__()`.

## Testing
The fix is verified by code inspection — `set_model()` now 
matches the pipeline initialization parameters used in 
`__init__()`. Both now use `max_new_tokens=1024` consistently.