### PR TITLE
fix API user quota logic flaw

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -51,7 +51,6 @@ def check_quota(api_key: str) -> bool:
     
     if api_key not in user_quotas:
         user_quotas[api_key] = {"count": 0, "date": today}
-        return True
         
     # reset quota daily
     if user_quotas[api_key]["date"] != today:


### PR DESCRIPTION
### Summary
Prior to this fix, the application bypassed quota incrementation for brand new API key requests. When a new API key was used, it returned `True` immediately without falling through to the proper count increment logic. This essentially gave new users an extra uncounted API request on their first use.
This fix removes the early return for new keys, initializes the quota tracking dictionary properly, and allows the execution to smoothly fall through to the proper increment logic at the bottom of the function.

### Screenshots
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/22079852-fe2d-46e0-b7f0-ce9fc7e1a364" />
As seen in the screenshot, before this fix the UI shows "100/100" remaining quota even after the user successfully received a RAG response to their first prompt, clearly demonstrating the bypassed increment.

### After Fixing
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/e3c9ef7b-f073-45d3-961b-e626dc9fb759" />
It can be seen from the screenshot that now the quota is updated for the first api request as well