### PR TITLE
Add Pydantic request validation for /ask-llm endpoint

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -2,6 +2,7 @@
 API routes for Sugar-AI.
 """
 from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
+from app.main import QuestionRequest           
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 import time
@@ -19,7 +20,13 @@ from app.config import settings
 class ChatMessage(BaseModel):
     role: str  # "system", "user", "assistant" 
     content: str
-
+class QuestionRequest(BaseModel):
+    question: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="User question"
+    )
 class PromptedLLMRequest(BaseModel):
     """Request model for ask-llm-prompted endpoint"""
     chat: bool = Field(False, description="Enable chat mode (uses messages instead of question)")
@@ -82,10 +89,11 @@ def verify_api_key(api_key: Optional[str] = Header(None, alias="X-API-Key"), req
 
 @router.post("/ask")
 async def ask_question(
-    question: str, 
-    user_info: dict = Depends(verify_api_key), 
+    data: QuestionRequest,
+    user_info: dict = Depends(verify_api_key),
     request: Request = None
 ):
+    question = data.question
     """Process a question using RAG pipeline"""
     start_time = time.time()
     
@@ -120,10 +128,11 @@ async def ask_question(
 
 @router.post("/ask-llm")
 async def ask_llm(
-    question: str, 
+    data: QuestionRequest,
     user_info: dict = Depends(verify_api_key), 
     request: Request = None
 ):
+    question = data.question
     """Process a question with direct LLM call (no retrieval)"""
     start_time = time.time()
     

--- a/main.py
+++ b/main.py
@@ -27,7 +27,15 @@ from app import create_app
 from app.database import get_db
 from app.auth import sync_env_keys_to_db
 from app.config import settings
+from pydantic import BaseModel, Field
 
+class QuestionRequest(BaseModel):
+    question: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="User question for the RAG system"
+    )
 # setup logging
 logger = logging.getLogger("sugar-ai")
 


### PR DESCRIPTION
This PR introduces request validation for the `/ask-llm` endpoint using a Pydantic model.

Previously, the endpoint could accept empty or excessively long questions, which might lead to unnecessary processing or unexpected behavior in the AI pipeline. This change adds validation constraints to ensure the `question` field contains meaningful input within a reasonable length.

By validating the request at the API layer, this improves reliability and prevents invalid requests from reaching the LLM processing stage.
