### PR TITLE
Add /health endpoint for API health check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,7 +57,9 @@ def create_app() -> FastAPI:
     from app.routes.auth import router as auth_router
     from app.routes.web import router as web_router
     from app.routes.webhook import router as webhook_router
+    from app.routes.main import router as main_router
     
+    app.include_router(main_router)
     app.include_router(api_router)
     app.include_router(admin_router)
     app.include_router(auth_router)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -14,3 +14,12 @@ templates = Jinja2Templates(directory="templates")
 async def root(request: Request):
     """Serve the root welcome page with links to documentation"""
     return templates.TemplateResponse("welcome.html", {"request": request})
+
+@router.get("/health")
+async def health_check():
+    return {
+        "status": "ok",
+        "service": "Sugar-AI",
+        "version": "1.0"
+    }
+    


### PR DESCRIPTION
## Description

This PR adds a `/health` endpoint to the Sugar-AI API.

The endpoint provides a simple way to check if the service is running and responding correctly. It returns a small JSON response containing the service status and version information.

Health check endpoints are commonly used by deployment and monitoring systems to verify that an API is available and functioning properly.

## Example Response

{
"status": "ok",
"service": "Sugar-AI",
"version": "1.0"
}
