### PR TITLE
fix: pin transformers below 5.0.0 to fix generation_config warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.45.2
+transformers>=4.45.2,<5.0.0
 torch>=1.12.1
 accelerate>=0.26.0
 faiss-cpu


### PR DESCRIPTION
## Problem
Running any endpoint produces this warning on every request:

Both `max_new_tokens` (=1024) and `max_length`(=20) seem to 
have been set. `max_new_tokens` will take precedence.

## Root Cause
`requirements.txt` specifies `transformers>=4.45.2` which 
allows transformers 5.x to be installed. transformers 5.x 
introduced stricter generation config handling — it raises 
a warning when the model's `generation_config.json` and 
pipeline parameters conflict.

transformers 4.x silently merged these configs.
transformers 5.x warns on every single request.

## Fix
Pin transformers to `<5.0.0` until the codebase is updated 
for full transformers 5.x compatibility.

## Testing
Tested on:
- Windows 11
- Python 3.13
- torch 2.10.0
- transformers 5.3.0 → warning appears
- transformers 4.x   → warning gone

Fixes #63
```

---

## Before Clicking Submit — Check This

Make sure at the top of the PR page it shows:
```
base repository: sugarlabs/sugar-ai    base: main
head repository: Ravi-Poddar26/sugar-ai  compare: fix/pin-transformers-version