### PR TITLE
fix: prevent app crash when webhook env vars are unset

### DIFF
--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -35,20 +35,28 @@ WEBHOOK_SECRET = os.getenv('WEBHOOK_SECRET')
 REPO_PATH_LOCALLY = os.getenv('REPO_PATH_LOCALLY')
 GIT_PATH = os.getenv('GIT_PATH')
 
-if not WEBHOOK_SECRET:
-    logger.error("WEBHOOK_SECRET not found in .env file")
-    raise ValueError("WEBHOOK_SECRET is required")
+_webhook_configured = all([WEBHOOK_SECRET, REPO_PATH_LOCALLY, GIT_PATH])
 
-if not REPO_PATH_LOCALLY:
-    logger.error("REPO_PATH_LOCALLY not found in .env file")
-    raise ValueError("REPO_PATH_LOCALLY is required")
+if not _webhook_configured:
+    _missing = [
+        name for name, val in [
+            ("WEBHOOK_SECRET", WEBHOOK_SECRET),
+            ("REPO_PATH_LOCALLY", REPO_PATH_LOCALLY),
+            ("GIT_PATH", GIT_PATH),
+        ]
+        if not val
+    ]
+    logger.warning(
+        "Webhook is disabled — missing env var(s): %s. "
+        "The /webhook endpoint will return 503 until they are set.",
+        ", ".join(_missing),
+    )
 
-if not GIT_PATH:
-    logger.error("GIT_PATH not found in .env file")
-    raise ValueError("GIT_PATH is required")
 
 def verify_github_signature(body: bytes, signature: str) -> bool:
     """Verify GitHub webhook signature"""
+    if not _webhook_configured:
+        return False
     if not signature:
         return False
     
@@ -57,7 +65,6 @@ def verify_github_signature(body: bytes, signature: str) -> bool:
         if sha_name != 'sha256':
             return False
         
-        # Create HMAC using request body and webhook secret
         mac = hmac.new(
             WEBHOOK_SECRET.encode('utf-8'), 
             msg=body, 
@@ -72,8 +79,16 @@ def verify_github_signature(body: bytes, signature: str) -> bool:
 @router.post("/webhook")
 async def webhook(request: Request):
     """GitHub webhook endpoint for handling repository updates"""
+    if not _webhook_configured:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "error",
+                "message": "Webhook is not configured — required env vars are missing",
+            },
+        )
+
     try:
-        # Read the request body
         body = await request.body()
         signature = request.headers.get('X-Hub-Signature-256')
         


### PR DESCRIPTION
`webhook.py` raises `ValueError` at module level (lines 38-48) when
`WEBHOOK_SECRET`, `REPO_PATH_LOCALLY`, or `GIT_PATH` are empty.
Since `create_app()` imports this module, the entire app crashes on
startup if these values aren't set.

These vars are only needed in production for GitHub webhook CI/CD,
but any developer who copies `.example.env` without filling them in
gets a crash before any endpoint is registered.

Replaced the hard crashes with logged warnings and a `_webhook_configured`
flag. The `/webhook` endpoint now returns 503 when not configured.

**Before** (app crashes on import):

<img width="639" height="111" alt="Screenshot 2026-03-11 at 6 38 35 PM" src="https://github.com/user-attachments/assets/ce45aba9-7d40-4759-915e-218e601dc2b1" />


**After** (app starts, webhook returns 503):

<img width="639" height="103" alt="Screenshot 2026-03-11 at 6 39 28 PM" src="https://github.com/user-attachments/assets/6554f91b-2e91-4d56-ad0a-efad5675f1cb" />
