### PR TITLE
fix: pin transformers below 5.0.0 to avoid generation_config warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.45.2
+transformers>=4.45.2,<5.0.0
 torch>=1.12.1
 accelerate>=0.26.0
 faiss-cpu


### PR DESCRIPTION
Pin `transformers` to `<5.0.0` in `requirements.txt` to prevent generation configuration warnings introduced in `transformers` 5.x.
This ensures compatibility with the current codebase.

Fixes #63
