### PR TITLE
Add lazy initialization and FAISS caching for vector store

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -3,6 +3,7 @@ AI functionality for Sugar-AI, including RAG and LLM components.
 """
 import os
 import torch
+import logging
 from transformers import pipeline
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
@@ -11,6 +12,7 @@ from langchain_core.runnables import RunnablePassthrough
 from langchain_core.prompts import ChatPromptTemplate
 from typing import Optional, List
 import app.prompts as prompts
+logger = logging.getLogger("sugar-ai")
 
 def format_docs(docs):
     """Return document content separated by newlines"""
@@ -118,10 +120,25 @@ class RAGAgent:
                 all_documents.extend(documents)
         
         embeddings = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/all-MiniLM-L6-v2"
+        model_name="sentence-transformers/all-MiniLM-L6-v2"
         )
-        
-        vector_store = FAISS.from_documents(all_documents, embeddings)
+
+        index_path = "vector_store"
+
+        # Load existing FAISS index if available
+        if os.path.exists(index_path):
+            logger.info("Loading existing FAISS vector store...")
+            vector_store = FAISS.load_local(
+                index_path,
+                embeddings,
+                allow_dangerous_deserialization=True
+            )
+
+        else:
+            logger.info("Creating new FAISS vector store...")
+            vector_store = FAISS.from_documents(all_documents, embeddings)
+            vector_store.save_local(index_path)
+
         self.retriever = vector_store.as_retriever()
         return self.retriever
 

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -38,9 +38,8 @@ router = APIRouter(tags=["api"])
 # setup logging
 logger = logging.getLogger("sugar-ai")
 
-# load ai agent and document paths
+# load ai agent 
 agent = RAGAgent(model=settings.DEFAULT_MODEL)
-agent.retriever = agent.setup_vectorstore(settings.DOC_PATHS)
 
 # user quotas tracking
 user_quotas: Dict[str, Dict] = {}
@@ -93,6 +92,11 @@ async def ask_question(
     logger.info(f"REQUEST - /ask - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
     
     try:
+        # Lazy load vector store if not initialized
+        if agent.retriever is None:
+            logger.info("Initializing vector store...")
+            agent.setup_vectorstore(settings.DOC_PATHS)
+            
         answer = agent.run(question)
         
         # log completion


### PR DESCRIPTION
This change improves the initialization of the RAG vector store by introducing
lazy loading and FAISS index caching.

Previously, the vector store was built during server startup, which caused
slower startup times and recomputation of embeddings on every restart.

Changes:
- Initialize the retriever lazily when the /ask endpoint is first used
- Persist the FAISS index locally
- Load the existing index if available instead of rebuilding embeddings

Benefits:
- Faster server startup
- Avoids recomputing embeddings unnecessarily
- Improves performance when working with larger document sets