### PR TITLE
Make embedding model configurable

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -3,6 +3,7 @@ AI functionality for Sugar-AI, including RAG and LLM components.
 """
 import os
 import torch
+from app.config import settings
 from transformers import pipeline
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
@@ -116,9 +117,8 @@ class RAGAgent:
                     loader = TextLoader(file_path)
                 documents = loader.load()
                 all_documents.extend(documents)
-        
         embeddings = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/all-MiniLM-L6-v2"
+            model_name=settings.EMBEDDING_MODEL
         )
         
         vector_store = FAISS.from_documents(all_documents, embeddings)

--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     DEFAULT_MODEL: str = os.getenv("DEFAULT_MODEL", "Qwen/Qwen2-1.5B-Instruct")
     DOC_PATHS: List[str] = json.loads(os.getenv("DOC_PATHS", '["./docs/Pygame Documentation.pdf", "./docs/Python GTK+3 Documentation.pdf", "./docs/Sugar Toolkit Documentation.pdf"]'))
     MAX_DAILY_REQUESTS: int = int(os.getenv("MAX_DAILY_REQUESTS", 100))
+    EMBEDDING_MODEL: str = "sentence-transformers/all-MiniLM-L6-v2"
     
     # OAuth
     github_client_id: Optional[str] = None


### PR DESCRIPTION
This PR makes the embedding model used by the FAISS vector store configurable.

Previously, the embedding model was hardcoded to
sentence-transformers/all-MiniLM-L6-v2 in ai.py. This prevented users
from selecting alternative embedding models based on their hardware,
language, or performance requirements.

This change introduces a new configuration parameter:

EMBEDDING_MODEL

The embedding model can now be specified through configuration
without modifying the source code, while keeping the default
behavior unchanged.