### PR TITLE
Title: Add /models endpoint to return configured model

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -335,13 +335,8 @@ async def change_model(
         raise HTTPException(status_code=500, detail=f"Error changing model: {str(e)}")
 
 @router.get("/models")
-async def get_models():
-    """Return list of available AI models"""
+def get_models():
     return {
-        "models": [
-            "Qwen2-1.5B",
-            "Mistral",
-            "Llama"
-        ],
-        "default_model": settings.DEFAULT_MODEL
+        "current_model": settings.DEFAULT_MODEL,
+        "provider": settings.AI_PROVIDER if hasattr(settings, 'AI_PROVIDER') else "huggingface"
     }

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -38,6 +38,12 @@ router = APIRouter(tags=["api"])
 # setup logging
 logger = logging.getLogger("sugar-ai")
 
+AVAILABLE_MODELS = [
+    "Qwen2-1.5B",
+    "Mistral",
+    "Llama"
+]
+
 # load ai agent and document paths
 agent = RAGAgent(model=settings.DEFAULT_MODEL)
 agent.retriever = agent.setup_vectorstore(settings.DOC_PATHS)
@@ -327,3 +333,15 @@ async def change_model(
     except Exception as e:
         logger.error(f"Error changing model to {model} by {user_info['name']}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error changing model: {str(e)}")
+
+@router.get("/models")
+async def get_models():
+    """Return list of available AI models"""
+    return {
+        "models": [
+            "Qwen2-1.5B",
+            "Mistral",
+            "Llama"
+        ],
+        "default_model": settings.DEFAULT_MODEL
+    }


### PR DESCRIPTION
## Summary
Add a new GET /models endpoint that returns the currently configured AI model.

## Problem
Clients had no way to know which AI model is currently configured
without inspecting the server configuration directly.

## Solution
Added a GET /models endpoint that returns only the currently configured
model from settings, instead of a static hardcoded list.
This reflects how sugar-ai actually works — any model can be set via .env.

## Changes
- Updated /models endpoint in app/routes/api.py
- Endpoint now returns current_model and provider from settings