### PR TITLE
fix: make output parsing and chat normalization model-agnostic

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -23,13 +23,23 @@ def combine_messages(x):
     return str(x)
 
 def extract_answer_from_output(outputs):
-    """Extract the answer text from model output"""
-    generated_text = outputs[0]['generated_text']
+    """Extract the answer text from model output safely."""
+    if not outputs:
+        return ""
+
+    first = outputs[0] or {}
+    generated_text = first.get("generated_text")
+    if not isinstance(generated_text, str):
+        return ""
 
     if "Child-friendly answer:" in generated_text:
         return generated_text.split("Child-friendly answer:")[-1].strip()
-    
-    return generated_text.split("Answer:")[-1].strip()
+
+    if "Answer:" in generated_text:
+        return generated_text.split("Answer:")[-1].strip()
+
+    # Fallback: return the full generated text trimmed.
+    return generated_text.strip()
 
 
 class RAGAgent:
@@ -289,9 +299,9 @@ class RAGAgent:
         for i, msg in enumerate(non_system_messages):
             role = msg.get("role")
             content = msg.get("content", "")
-            
-            # Convert assistant to model
-            if role == "assistant":
+
+            # Convert assistant to model only for Gemma-style chat templates
+            if role == "assistant" and "gemma" in str(self.model_name).lower():
                 role = "model"
             
             # Merge system into first user message (if first message is user)

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Dict, Optional, List
 
 from app.database import get_db, APIKey
-from app.ai import RAGAgent
+from app.ai import RAGAgent, extract_answer_from_output
 from app.config import settings
 
 # Pydantic models for chat completions
@@ -132,7 +132,7 @@ async def ask_llm(
     
     try:
         response = agent.model(question)
-        answer = response[0]['generated_text'].split("Answer:")[-1].strip()
+        answer = extract_answer_from_output(response)
         
         process_time = time.time() - start_time
         logger.info(f"RESPONSE - User: {user_info['name']} - Success - Time: {process_time:.2f}s")


### PR DESCRIPTION
The current code has two model-specific assumptions that break with non-Gemma models:

1. `_normalize_chat_messages()` always converts "assistant" role to "model", which is a Gemma-specific convention. Other models (including the default Qwen) expect "assistant".

2. `extract_answer_from_output()` splits on "Answer:" with no fallback. If the model doesn't produce this exact marker, the full prompt+response is returned as the answer.

Additionally, `/ask-llm` duplicates the brittle parsing inline instead of reusing the shared helper.

Changes:
- Only apply assistant→model role conversion for Gemma models
- Add defensive checks and a proper fallback to extract_answer_from_output()
- Reuse extract_answer_from_output() in /ask-llm endpoint