### PR TITLE
fix: remove duplicate h2 attribute in welcome.html

### DIFF
--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -276,7 +276,7 @@ print(result["answer"])
   </div>
   
   <div class="documentation-section">
-    <h2 h2 id="docs" class="section-title">API Endpoints Documentation</h2>
+    <h2 id="docs" class="section-title">API Endpoints Documentation</h2>
     
     <div class="endpoint">
       <h3>Ask Question (RAG Enhanced)</h3>


### PR DESCRIPTION
## Summary:-
- Fixes a minor HTML syntax error in the welcome.html file inside templates folder

## The Problem:-
- In line 279 theres this line: "h2 h2 id="docs" class="section-title""
- Theres this continous h2 right after the tag which considers this h2 as an attribute

## The Fix:-
- Remove the duplicate h2 after the first one.