### PR TITLE
fix: move /change-model credentials from query params to request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ The response will include the user name:
 Users with `can_change_model: true` permission can change the model:
 
 ```sh
-curl -X POST "http://localhost:8000/change-model?model=Qwen/Qwen2-1.5B-Instruct&api_key=sugarai2024&password=sugarai2024"
+curl -X POST "http://localhost:8000/change-model" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen2-1.5B-Instruct", "api_key": "sugarai2024", "password": "sugarai2024"}'
 ```
 
 #### Why User Names Are Useful

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,7 +1,7 @@
 """
 API routes for Sugar-AI.
 """
-from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Header, Request
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 import time
@@ -32,6 +32,12 @@ class PromptedLLMRequest(BaseModel):
     temperature: float = Field(0.7, description="Temperature for sampling")
     top_p: float = Field(0.9, description="Top-p (nucleus) sampling parameter")
     top_k: int = Field(50, description="Top-k sampling parameter")
+
+class ChangeModelRequest(BaseModel):
+    """Request model for change-model endpoint"""
+    model: str = Field(..., min_length=1, description="HuggingFace model identifier to switch to")
+    api_key: str = Field(..., min_length=1, description="API key for authentication")
+    password: str = Field(..., min_length=1, description="Admin password for model changes")
 
 router = APIRouter(tags=["api"])
 
@@ -298,32 +304,30 @@ async def debug(
 
 @router.post("/change-model")
 async def change_model(
-    model: str, 
-    api_key: str = Query(...), 
-    password: str = Query(...), 
+    request_data: ChangeModelRequest,
     request: Request = None
 ):
     """Change the model used by the RAG agent (admin only)"""
     client_ip = request.client.host if request else "unknown"
-    logger.info(f"REQUEST - /change-model - API Key: {api_key[:5]}... - IP: {client_ip} - Model: {model}")
-    
-    if api_key not in settings.API_KEYS:
-        logger.warning(f"Invalid API key used for model change: {api_key[:5]}... from {client_ip}")
+    logger.info(f"REQUEST - /change-model - API Key: {request_data.api_key[:5]}... - IP: {client_ip} - Model: {request_data.model}")
+
+    if request_data.api_key not in settings.API_KEYS:
+        logger.warning(f"Invalid API key used for model change: {request_data.api_key[:5]}... from {client_ip}")
         raise HTTPException(status_code=401, detail="Invalid API key")
-    
-    user_info = settings.API_KEYS[api_key]
+
+    user_info = settings.API_KEYS[request_data.api_key]
     if not user_info.get("can_change_model", False):
         logger.warning(f"Unauthorized model change attempt by: {user_info['name']} from {client_ip}")
         raise HTTPException(status_code=403, detail="User doesn't have permission to change model")
-    
-    if password != settings.MODEL_CHANGE_PASSWORD:
+
+    if request_data.password != settings.MODEL_CHANGE_PASSWORD:
         logger.warning(f"Invalid password for model change by: {user_info['name']} from {client_ip}")
         raise HTTPException(status_code=403, detail="Invalid model change password")
-    
+
     try:
-        agent.set_model(model)
-        logger.info(f"Model changed to {model} by {user_info['name']}")
-        return {"message": f"Model changed to {model}", "user": user_info["name"]}
+        agent.set_model(request_data.model)
+        logger.info(f"Model changed to {request_data.model} by {user_info['name']}")
+        return {"message": f"Model changed to {request_data.model}", "user": user_info["name"]}
     except Exception as e:
-        logger.error(f"Error changing model to {model} by {user_info['name']}: {str(e)}")
+        logger.error(f"Error changing model to {request_data.model} by {user_info['name']}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error changing model: {str(e)}")

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -511,15 +511,14 @@ Content-Type: application/json</pre>
     <div class="endpoint admin-only">
       <h3>Change Model (Admin Only)</h3>
       <div class="endpoint-method">POST</div>
-      <div class="endpoint-url">/change-model?model={model_name}&api_key={admin_key}&password={admin_password}</div>
+      <div class="endpoint-url">/change-model</div>
       <p>Change the LLM model being used for responses. Requires admin API key and password.</p>
-      
+
       <div class="endpoint-details">
         <h4>Example Request:</h4>
-        <pre>curl -X POST "http://localhost:8000/change-model?model=Qwen/Qwen2-1.5B-Instruct&api_key=admin_key&password=admin_password"</pre>
-        
-       
-        </ul>
+        <pre>curl -X POST "http://localhost:8000/change-model" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen2-1.5B-Instruct", "api_key": "admin_key", "password": "admin_password"}'</pre>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The `/change-model` endpoint accepts `api_key` and `password` as URL query parameters (`Query(...)`). This means credentials appear in server access logs, browser history, proxy caches, and HTTP Referer headers. Sugar-AI is a children's education platform, making credential exposure especially sensitive.

**Before:**

    POST /change-model?model=Qwen/Qwen2-1.5B-Instruct&api_key=sugarai2024&password=sugarai2024

**After:**

    POST /change-model
    Content-Type: application/json

    {"model": "Qwen/Qwen2-1.5B-Instruct", "api_key": "sugarai2024", "password": "sugarai2024"}

## Solution

- Add `ChangeModelRequest` Pydantic model with `min_length=1` validation on all fields, consistent with the pattern used by `PromptedLLMRequest`
- Rewrite `/change-model` handler to read from the JSON request body instead of URL query parameters
- Update documentation in `welcome.html` and `README.md` to show JSON body usage
- Remove an orphaned `</ul>` tag in `welcome.html` that had no matching `<ul>` (pre-existing)
- Remove unused `Query` import and clean up trailing whitespace on blank lines in the handler

No changes to business logic, authentication flow, or response format.

**Note:** This is a breaking change for callers that pass credentials as query parameters. They will need to switch to sending a JSON request body. The deployed Sugar-AI instance currently has no known external callers of this admin-only endpoint beyond the development team.

Related: #87 applies the same pattern to the `/debug` endpoint. These two changes are independent and do not conflict.

## Testing

Verified that:
- `POST /change-model` with JSON body `{"model": "...", "api_key": "...", "password": "..."}` works correctly
- Empty `model`, `api_key`, or `password` returns HTTP 422 with validation error
- Old query-parameter style requests no longer pass credentials through the URL
