### PR TITLE
feat: provider abstraction layer — BaseProvider ABC + ProviderFactory [GSoC 2026 Draft]

### DIFF
--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+class BaseProvider(ABC):
+    """Abstract base class for all sugar-ai LLM providers."""
+
+    @abstractmethod
+    def generate(self, prompt: str, **kwargs) -> str:
+        ...
+
+    @abstractmethod
+    def chat(self, messages: list[dict], **kwargs) -> str:
+        ...
+
+    @abstractmethod
+    async def stream(
+        self, messages: list[dict], **kwargs
+    ) -> AsyncIterator[str]:
+        ...
+
+    @abstractmethod
+    def health_check(self) -> bool:
+        ...

--- a/app/providers/factory.py
+++ b/app/providers/factory.py
@@ -1,0 +1,14 @@
+import os
+from app.providers.base import BaseProvider
+
+def get_provider() -> BaseProvider:
+    provider = os.getenv("AI_PROVIDER", "huggingface_local")
+
+    if provider == "ollama":
+        from app.providers.ollama_provider import OllamaProvider
+        return OllamaProvider()
+    elif provider == "huggingface_local":
+        from app.providers.huggingface_provider import HuggingFaceLocalProvider
+        return HuggingFaceLocalProvider()
+    else:
+        raise ValueError(f"Unknown AI_PROVIDER: {provider}")


### PR DESCRIPTION
## GSoC 2026 — Provider Abstraction Layer: Foundation

This draft PR introduces the foundational files for the provider 
abstraction layer proposed in my GSoC 2026 application.

### What this adds

- `app/providers/base.py` — `BaseProvider` ABC with `generate()`, 
  `chat()`, `stream()`, `health_check()` abstract methods
- `app/providers/factory.py` — `get_provider()` reading `AI_PROVIDER` 
  from `.env`, defaulting to `huggingface_local` (zero regression)
- `app/providers/__init__.py` — package init

### Design decisions

**Default is `huggingface_local`** — existing behaviour is fully 
preserved. No deployment breaks if `AI_PROVIDER` is not set.

**RAGAgent integration point:** `app/routes/api.py` currently calls  
`RAGAgent(model=settings.DEFAULT_MODEL)`. After this project, that 
becomes:
```python
provider = get_provider()
agent = RAGAgent(provider=provider)
```
This PR establishes the interface that makes that change possible.

### What comes next (GSoC scope)

- `HuggingFaceLocalProvider` — wraps existing inference code
- `OllamaProvider` — local offline inference via `/api/generate`
- `HuggingFaceAPIProvider` — Inference API with token
- `CustomProvider` — any OpenAI-compatible endpoint
- Fallback chain with `health_check()` caching
- Full `pytest + mock` test suite (no real API needed in CI)

### Related

GSoC 2026 proposal: provider abstraction layer for sugar-ai  
Fixes known bug: `extract_answer_from_output()` breaks with 
non-HuggingFace model output format (verified with llama3, mistral)

---
*Draft — interface design open for mentor feedback before 
implementation begins.*
