### PR TITLE
add offline mode with lazy model loading

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -85,32 +85,11 @@ class RAGAgent:
                 torch_dtype=torch.float16,
                 device_map="auto"
             )
-            self.model = pipeline(
-                "text-generation",
-                model=model_obj,
-                tokenizer=tokenizer,
-                max_new_tokens=1024,
-                truncation=True,
-            )
-            
-            self.simplify_model = pipeline(
-                "text-generation",
-                model=model_obj,
-                tokenizer=tokenizer,
-                max_new_tokens=1024,
-                truncation=True,
-            )
+            self.model = None
+            self.simplify_model = None
         else:
-            self.model = pipeline(
-                "text-generation",
-                model=self.model_name,
-                max_new_tokens=1024,
-                truncation=True,
-                torch_dtype=dtype, # Use the dynamic dtype
-                device=device,     # Use the dynamic device
-            )
-
-            self.simplify_model = self.model
+            self.model = None
+            self.simplify_model = None
 
         self.retriever: Optional[FAISS] = None
         self.prompt = ChatPromptTemplate.from_template(prompts.PROMPT_TEMPLATE)
@@ -119,7 +98,53 @@ class RAGAgent:
         self.context_prompt = ChatPromptTemplate.from_template(prompts.CODE_CONTEXT_PROMPT)
         self.kids_debug_prompt = ChatPromptTemplate.from_template(prompts.KIDS_DEBUG_PROMPT)
         self.kids_context_prompt = ChatPromptTemplate.from_template(prompts.KIDS_CONTEXT_PROMPT)
+    def load_model(self):
+        """Load model only when needed (keeps original behavior)"""
+        if self.model is not None:
+           return
 
+        logger.info("Lazy loading model...")
+
+        device = 0 if torch.cuda.is_available() and not getattr(settings, "DEV_MODE", False) else -1
+        dtype = torch.float16 if device == 0 else torch.float32
+
+        if self.use_quant:
+            bnb_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_compute_dtype=torch.float16,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4"
+            )
+  
+            tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            model_obj = AutoModelForCausalLM.from_pretrained(
+                self.model_name,
+                quantization_config=bnb_config,
+                torch_dtype=torch.float16,
+                device_map="auto"
+            )
+
+            self.model = pipeline(
+                "text-generation",
+                model=model_obj,
+                tokenizer=tokenizer,
+                max_new_tokens=1024,
+                truncation=True,
+            )
+
+            self.simplify_model = self.model
+
+        else:
+            self.model = pipeline(
+                "text-generation",
+                model=self.model_name,
+                max_new_tokens=1024,
+                truncation=True,
+                torch_dtype=dtype,
+                device=device,
+            )
+
+            self.simplify_model = self.model
     def set_model(self, model: str) -> None:
         """Update the model used by the agent"""
         self.model_name = model
@@ -205,6 +230,12 @@ class RAGAgent:
 
     def run(self, question: str) -> str:
         """Process a question through the RAG pipeline"""
+        self.load_model()
+        if not self.retriever:
+            # No RAG → fallback to pure LLM
+            prompt = f"Question: {question}\nAnswer:"
+            response = self.model(prompt)
+            return extract_answer_from_output(response)
         # build chain components
         chain_input = {
             "context": self.retriever | format_docs,
@@ -398,3 +429,17 @@ class RAGAgent:
             
         except Exception as e:
             raise Exception(f"Error generating chat completion: {str(e)}")
+    
+    def run_rag_only(self, question: str) -> str:
+        """Return response using only retrieved documents (no LLM)"""
+        if not self.retriever:
+           return "No documents available for retrieval."
+
+        docs = self.retriever.invoke(question)
+
+        if not docs:
+           return "No relevant documents found."
+
+        context = "\n\n".join([doc.page_content for doc in docs[:3]])
+
+        return f"(Offline Mode)\n\nBased on retrieved documents:\n{context}"

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -15,6 +15,8 @@ from app.database import get_db, APIKey
 from app.ai import RAGAgent, extract_answer_from_output
 from app.config import settings
 
+OFFLINE_MODE = os.getenv("OFFLINE_MODE", "false").lower() == "true"
+
 # Pydantic models for chat completions
 class ChatMessage(BaseModel):
     role: str  # "system", "user", "assistant" 
@@ -39,7 +41,7 @@ router = APIRouter(tags=["api"])
 logger = logging.getLogger("sugar-ai")
 
 # Initialize the agent
-agent = None
+agent = RAGAgent()
 
 # user quotas tracking
 user_quotas: Dict[str, Dict] = {}
@@ -92,8 +94,12 @@ async def ask_question(
     logger.info(f"REQUEST - /ask - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
     
     try:
-        answer = agent.run(question)
-        
+        if OFFLINE_MODE:
+           answer = agent.run_rag_only(question)
+           mode = "offline"
+        else:
+           answer = agent.run(question)
+           mode = "llm"
         # log completion
         process_time = time.time() - start_time
         logger.info(f"RESPONSE - User: {user_info['name']} - Success - Time: {process_time:.2f}s")
@@ -111,6 +117,7 @@ async def ask_question(
         return {
             "answer": answer, 
             "user": user_info["name"],
+            "mode": mode,
             "quota": {"remaining": remaining, "total": settings.MAX_DAILY_REQUESTS}
         }
     except Exception as e:
@@ -130,6 +137,7 @@ async def ask_llm(
     logger.info(f"REQUEST - /ask-llm - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
     
     try:
+        agent.load_model()
         response = agent.model(question)
         answer = extract_answer_from_output(response)
         
@@ -184,6 +192,7 @@ async def ask_llm_prompted(
             # Convert Pydantic messages to dict format for the agent function
             messages_dict = [{"role": msg.role, "content": msg.content} for msg in request_data.messages]
             
+            agent.load_model()
             # Call the agent's chat completion function
             answer = agent.run_chat_completion(
                 messages=messages_dict,
@@ -227,6 +236,7 @@ async def ask_llm_prompted(
             logger.info(f"REQUEST - /ask-llm-prompted - User: {user_info['name']} - IP: {client_ip} - Question: {request_data.question[:200]}...")
             logger.info(f"CUSTOM PROMPT - User: {user_info['name']} - Prompt: {request_data.custom_prompt[:100]}...")
             
+            agent.load_model()
             answer = agent.run_with_custom_prompt(
                 question=request_data.question,
                 custom_prompt=request_data.custom_prompt,
@@ -275,6 +285,7 @@ async def debug(
     logger.info(f"REQUEST - /debug - User: {user_info['name']} - IP: {client_ip} - code: {code[:50]}...")
     
     try:
+        agent.load_model()
         response = agent.debug(code, context)
         answer = response
         


### PR DESCRIPTION
Introduce an OFFLINE_MODE flag to allow the system to run without invoking the LLM, returning retrieval-based responses instead. This enables usage in low-connectivity environments.

Move model initialization from startup to runtime (lazy loading) to prevent server startup failures when the model cannot be loaded.

Handle empty document sets safely by skipping vector store initialization, avoiding crashes during FAISS setup.

Allow direct LLM responses when no documents are available in online mode, ensuring the system remains functional without RAG context.