### PR TITLE
fix: replace max_length with max_new_tokens and add basic chat context budgeting

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -13,6 +13,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from typing import Optional, List
 import app.prompts as prompts
 from app.config import settings
+from app.context import ContextManager, ModelMetadata
 import logging
 logger = logging.getLogger("sugar-ai")
 
@@ -119,6 +120,14 @@ class RAGAgent:
         self.context_prompt = ChatPromptTemplate.from_template(prompts.CODE_CONTEXT_PROMPT)
         self.kids_debug_prompt = ChatPromptTemplate.from_template(prompts.KIDS_DEBUG_PROMPT)
         self.kids_context_prompt = ChatPromptTemplate.from_template(prompts.KIDS_CONTEXT_PROMPT)
+        self.ctx = ContextManager(
+            metadata=ModelMetadata(
+                model_name=self.model_name,
+                context_window=settings.CONTEXT_WINDOW,
+                max_output_tokens=settings.MAX_OUTPUT_TOKENS,
+            ),
+            count_tokens=lambda text: len(self.model.tokenizer.encode(text)),
+        )
 
     def set_model(self, model: str) -> None:
         """Update the model used by the agent"""
@@ -241,47 +250,46 @@ class RAGAgent:
         final_response = second_chain.invoke(first_response)
         return final_response
 
-    def run_with_custom_prompt(self, question: str, custom_prompt: str, 
-                             max_length: int = 1024, truncation: bool = True,
+    def run_with_custom_prompt(self, question: str, custom_prompt: str,
+                             truncation: bool = True,
                              repetition_penalty: float = 1.1, temperature: float = 0.7,
                              top_p: float = 0.9, top_k: int = 50) -> str:
-        """Process a question with custom prompt and generation parameters (no RAG)"""
-        
-        # Combine custom prompt with question
+        """Process a question with custom prompt and generation parameters (no RAG)."""
         full_prompt = f"{custom_prompt}\n\nQuestion: {question}\nAnswer:"
-        
-        # Generate response with custom parameters
+
+        if not self.ctx.fits_in_budget(full_prompt):
+            logger.warning(
+                "run_with_custom_prompt: prompt exceeds safe_input_budget (%d tokens). "
+                "Proceeding with HF truncation as fallback.",
+                self.ctx.metadata.safe_input_budget,
+            )
+
         try:
             response = self.model(
                 full_prompt,
-                max_length=max_length,
+                max_new_tokens=self.ctx.metadata.max_output_tokens,
                 truncation=truncation,
                 repetition_penalty=repetition_penalty,
                 temperature=temperature,
                 top_p=top_p,
                 top_k=top_k,
-                do_sample=True if temperature > 0 else False,
+                do_sample=temperature > 0,
                 pad_token_id=self.model.tokenizer.eos_token_id,
             )
-            
-            # Extract the answer from the generated text
+
             generated_text = response[0]['generated_text']
-            
-            # Remove the original prompt from the response
+
             if "Answer:" in generated_text:
                 answer = generated_text.split("Answer:")[-1].strip()
             else:
-                # Fallback: remove the input prompt
                 answer = generated_text.replace(full_prompt, "").strip()
-            
-            # Stop at double newlines - this is our main stopping condition, else model continues with generating next user input, which we don't want
+
+            # Stop at first double newline — prevents model from continuing as next user turn.
             if "\n\n" in answer:
-                # Find the first occurrence of double newlines and cut there
-                double_newline_pos = answer.find("\n\n")
-                answer = answer[:double_newline_pos].strip()
-            
+                answer = answer[:answer.find("\n\n")].strip()
+
             return answer
-            
+
         except Exception as e:
             raise Exception(f"Error generating response with custom prompt: {str(e)}")
 
@@ -354,47 +362,58 @@ class RAGAgent:
         return answer
 
 
-    def run_chat_completion(self, messages: list, 
-                        max_length: int = 1024, truncation: bool = True,
+    def run_chat_completion(self, messages: list,
+                        truncation: bool = True,
                         repetition_penalty: float = 1.1, temperature: float = 0.7,
                         top_p: float = 0.9, top_k: int = 50) -> str:
         """
         Process chat messages with chat template format and generation parameters.
-        """
 
-        # Normalize messages and build prompt using tokenizer's chat template
-        chat = self._normalize_chat_messages(messages)
+        Before calling the model, trims oldest non-system turns so the full
+        prompt fits within the configured context window.
+        """
+        # Separate system messages to measure their token cost independently.
+        system_msgs = [m for m in messages if m.get("role") == "system"]
+        user_msgs   = [m for m in messages if m.get("role") == "user"]
+
+        system_tokens  = sum(self.ctx.count_tokens(m.get("content", "")) for m in system_msgs)
+        new_user_tokens = self.ctx.count_tokens(user_msgs[-1].get("content", "")) if user_msgs else 0
+
+        trimmed = self.ctx.trim_chat_history(
+            messages,
+            system_tokens=system_tokens,
+            new_user_tokens=new_user_tokens,
+        )
+
+        chat = self._normalize_chat_messages(trimmed)
         full_prompt = self.model.tokenizer.apply_chat_template(
             chat,
             tokenize=False,
             add_generation_prompt=True,
         )
 
-        # Generate response with custom parameters
         try:
             response = self.model(
                 full_prompt,
-                max_length=max_length,
+                max_new_tokens=self.ctx.metadata.max_output_tokens,
                 truncation=truncation,
                 repetition_penalty=repetition_penalty,
                 temperature=temperature,
                 top_p=top_p,
                 top_k=top_k,
-                do_sample=True if temperature > 0 else False,
+                do_sample=temperature > 0,
                 pad_token_id=self.model.tokenizer.eos_token_id,
             )
-            
-            # Extract the answer from the generated text
+
             generated_text = response[0]['generated_text']
-            
-            # Extract only the new model response
+
             answer = self._extract_after_prompt(
                 generated_text,
                 full_prompt,
                 getattr(self.model.tokenizer, "eos_token", None),
             )
-            
+
             return answer
-            
+
         except Exception as e:
             raise Exception(f"Error generating chat completion: {str(e)}")

--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     MODEL_CHANGE_PASSWORD: str = ""
     DOC_PATHS: List[str] = Field(default_factory=list)
     MAX_DAILY_REQUESTS: int = 100
+    CONTEXT_WINDOW: int = 4096
+    MAX_OUTPUT_TOKENS: int = 1024
 
     # OAuth
     github_client_id: Optional[str] = None

--- a/app/context.py
+++ b/app/context.py
@@ -1,0 +1,88 @@
+"""
+Context-window management for Sugar-AI.
+
+Backend-agnostic: only requires a count_tokens(str) -> int callable.
+When a provider abstraction is added (issue #117), only that callable changes.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable, List
+import logging
+
+logger = logging.getLogger("sugar-ai")
+
+
+@dataclass
+class ModelMetadata:
+    model_name: str
+    context_window: int
+    max_output_tokens: int
+
+    @property
+    def safe_input_budget(self) -> int:
+        """Tokens available for input = context_window - reserved output space."""
+        return self.context_window - self.max_output_tokens
+
+
+@dataclass
+class ContextManager:
+    metadata: ModelMetadata
+    count_tokens: Callable[[str], int]
+
+    def trim_chat_history(
+        self,
+        messages: List[dict],
+        system_tokens: int = 0,
+        new_user_tokens: int = 0,
+    ) -> List[dict]:
+        """
+        Drop oldest non-system turns until history fits within safe_input_budget.
+
+        Rules:
+        - System messages are never dropped.
+        - Walks newest-to-oldest, skipping any turn that would overflow
+          (does not stop at first overflow — a large old turn should not
+          evict smaller newer turns that fit).
+        - Returns [] for history if budget is already exhausted by system + user.
+        """
+        budget = self.metadata.safe_input_budget - system_tokens - new_user_tokens
+
+        if budget <= 0:
+            logger.warning(
+                "safe_input_budget exhausted by system prompt + user turn alone "
+                "(system_tokens=%d, new_user_tokens=%d, safe_input_budget=%d).",
+                system_tokens,
+                new_user_tokens,
+                self.metadata.safe_input_budget,
+            )
+            return []
+
+        system_msgs = [m for m in messages if m.get("role") == "system"]
+        history = [m for m in messages if m.get("role") != "system"]
+
+        kept: List[dict] = []
+        used = 0
+        for msg in reversed(history):
+            tokens = self.count_tokens(msg.get("content", ""))
+            if used + tokens <= budget:
+                kept.append(msg)
+                used += tokens
+            else:
+                logger.info(
+                    "History trim: dropping role=%s tokens=%d (used=%d budget=%d).",
+                    msg.get("role"),
+                    tokens,
+                    used,
+                    budget,
+                )
+
+        kept.reverse()
+        dropped = len(history) - len(kept)
+        if dropped:
+            logger.info("Trimmed %d message(s) from chat history.", dropped)
+
+        return system_msgs + kept
+
+    def fits_in_budget(self, text: str) -> bool:
+        """True if text fits within safe_input_budget."""
+        return self.count_tokens(text) <= self.metadata.safe_input_budget

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -26,7 +26,6 @@ class PromptedLLMRequest(BaseModel):
     question: Optional[str] = Field(None, description="The question to ask (required if chat=False)")
     custom_prompt: Optional[str] = Field(None, description="Custom prompt to replace system prompt (required if chat=False)")
     messages: Optional[List[ChatMessage]] = Field(None, description="List of chat messages (required if chat=True)")
-    max_length: int = Field(1024, description="Maximum length of generated text")
     truncation: bool = Field(True, description="Whether to truncate input if too long")
     repetition_penalty: float = Field(1.1, description="Repetition penalty")
     temperature: float = Field(0.7, description="Temperature for sampling")
@@ -187,7 +186,6 @@ async def ask_llm_prompted(
             # Call the agent's chat completion function
             answer = agent.run_chat_completion(
                 messages=messages_dict,
-                max_length=request_data.max_length,
                 truncation=request_data.truncation,
                 repetition_penalty=request_data.repetition_penalty,
                 temperature=request_data.temperature,
@@ -211,7 +209,6 @@ async def ask_llm_prompted(
                 "user": user_info["name"],
                 "quota": {"remaining": remaining, "total": settings.MAX_DAILY_REQUESTS},
                 "generation_params": {
-                    "max_length": request_data.max_length,
                     "truncation": request_data.truncation,
                     "repetition_penalty": request_data.repetition_penalty,
                     "temperature": request_data.temperature,
@@ -230,7 +227,6 @@ async def ask_llm_prompted(
             answer = agent.run_with_custom_prompt(
                 question=request_data.question,
                 custom_prompt=request_data.custom_prompt,
-                max_length=request_data.max_length,
                 truncation=request_data.truncation,
                 repetition_penalty=request_data.repetition_penalty,
                 temperature=request_data.temperature,
@@ -246,7 +242,6 @@ async def ask_llm_prompted(
                 "user": user_info["name"],
                 "quota": {"remaining": remaining, "total": settings.MAX_DAILY_REQUESTS},
                 "generation_params": {
-                    "max_length": request_data.max_length,
                     "truncation": request_data.truncation,
                     "repetition_penalty": request_data.repetition_penalty,
                     "temperature": request_data.temperature,
@@ -326,3 +321,15 @@ async def change_model(
     except Exception as e:
         logger.error(f"Error changing model to {model} by {user_info['name']}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error changing model: {str(e)}")
+
+
+@router.get("/model-info")
+async def model_info(user_info: dict = Depends(verify_api_key)):
+    """Return active model metadata including context window and token budgets."""
+    meta = agent.ctx.metadata
+    return {
+        "model_name": meta.model_name,
+        "context_window": meta.context_window,
+        "max_output_tokens": meta.max_output_tokens,
+        "safe_input_budget": meta.safe_input_budget,
+    }


### PR DESCRIPTION
 Partially addresses #120

  ## Summary

  This PR fixes two concrete problems in the current Hugging Face generation path:

  1. prompted/chat generation used max_length, which limits total tokens (input + output) and could truncate the prompt itself before generation
  2. chat completions accepted full message history with no application-level trimming, making long conversations overflow context unpredictably

  ## What changed

  ### app/context.py

  Adds a small context-management helper for the current backend path:

  - ModelMetadata stores:
      - model_name
      - context_window
      - max_output_tokens
      - derived safe_input_budget
  - ContextManager.trim_chat_history(...) drops older non-system messages to fit the configured input budget
  - ContextManager.fits_in_budget(...) provides a simple overflow check for single prompts

  ### app/ai.py

  - initializes self.ctx in RAGAgent
  - updates run_chat_completion(...) to trim chat history before rendering the chat prompt
  - updates run_with_custom_prompt(...) to warn when the prompt exceeds the configured input budget
  - replaces max_length with max_new_tokens in the explicit prompted/chat generation calls

  ### app/config.py

  Adds configurable settings for:

  - CONTEXT_WINDOW
  - MAX_OUTPUT_TOKENS

  ### app/routes/api.py

  - removes max_length from PromptedLLMRequest
  - adds GET /model-info to expose:
      - model_name
      - context_window
      - max_output_tokens
      - safe_input_budget

  ## Scope

  This PR adds basic application-level safeguards for the current inference path.

  It does not yet implement:

  - conversation summarization/compression
  - retrieval-context budgeting
  - provider-agnostic runtime abstraction
  - model-derived context-window discovery across backends

