### PR TITLE
Fix race condition in quota tracking using thread lock

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -10,6 +10,8 @@ import os
 import json
 from datetime import datetime
 from typing import Dict, Optional, List
+from threading import Lock
+from collections import defaultdict
 
 from app.database import get_db, APIKey
 from app.ai import RAGAgent, extract_answer_from_output
@@ -41,26 +43,29 @@ logger = logging.getLogger("sugar-ai")
 # Initialize the agent
 agent = None
 
-# user quotas tracking
-user_quotas: Dict[str, Dict] = {}
+# thread-safe user quota tracking
+quota_lock = Lock()
+
+user_quotas = defaultdict(lambda: {"count": 0, "date": None})
 
 def check_quota(api_key: str) -> bool:
-    """Check if a user has exceeded their daily quota"""
-    today = datetime.now().date()
-    
-    if api_key not in user_quotas:
-        user_quotas[api_key] = {"count": 0, "date": today}
-        return True
-        
-    # reset quota daily
-    if user_quotas[api_key]["date"] != today:
-        user_quotas[api_key]["count"] = 0
-        user_quotas[api_key]["date"] = today
-        
-    if user_quotas[api_key]["count"] >= settings.MAX_DAILY_REQUESTS:
-        return False
-        
-    user_quotas[api_key]["count"] += 1
+    """Check if a user has exceeded their daily quota safely"""
+
+    with quota_lock:
+
+        today = datetime.now().date()
+
+        quota = user_quotas[api_key]
+
+        # reset quota daily
+        if quota["date"] != today:
+            quota["count"] = 0
+            quota["date"] = today
+
+        if quota["count"] >= settings.MAX_DAILY_REQUESTS:
+            return False
+
+        quota["count"] += 1
     return True
 
 def verify_api_key(api_key: Optional[str] = Header(None, alias="X-API-Key"), request: Request = None):


### PR DESCRIPTION
## Summary

This PR fixes a race condition in the `user_quotas` in-memory tracking system used for API rate limiting.

Previously, the quota dictionary was updated without any synchronization mechanism, which could lead to inconsistent behavior under concurrent requests.

---

## Problem

The original implementation used a shared global dictionary:

```python
user_quotas: Dict[str, Dict] = {}
```

This structure was modified directly in multiple requests:

* Initialization of new users was not thread-safe
* Increment operations were not atomic
* Concurrent requests could lead to incorrect quota counts or bypassing limits

---

## Solution

Introduced thread-safety using `threading.Lock` to ensure atomic access to the quota dictionary.

Key changes:

* Added a lock to synchronize quota updates
* Wrapped quota check + increment inside a critical section
* Ensured consistent daily reset logic under concurrency

---

## Impact

* Prevents race conditions in quota tracking
* Ensures accurate request counting under concurrent load
* Improves reliability of rate-limiting logic

---

## Testing

* Verified `/ask-llm` endpoint with multiple sequential requests
* Simulated rapid requests using looped curl commands
* Confirmed quota decreases correctly per request
* Server runs without errors after changes

---

## Notes

This is an in-memory solution suitable for single-instance deployments. For distributed systems, a centralized store like Redis would be more appropriate.
