### PR TITLE
Phase-1 : Refactor/provider abstraction

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -134,21 +134,10 @@ class RAGAgent:
         return final_response
 
     def run_with_custom_prompt(self, question: str, custom_prompt: str,
-                               max_length: int = 1024, truncation: bool = True,
-                               repetition_penalty: float = 1.1, temperature: float = 0.7,
-                               top_p: float = 0.9, top_k: int = 50) -> str:
+                               params: Optional[GenerationParams] = None) -> str:
         """Process a question with custom prompt and parameters (no RAG)."""
+        params = params or GenerationParams()
         full_prompt = f"{custom_prompt}\n\nQuestion: {question}\nAnswer:"
-
-        params = GenerationParams(
-            max_new_tokens=max_length,
-            truncation=truncation,
-            repetition_penalty=repetition_penalty,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            do_sample=temperature > 0,
-        )
 
         try:
             answer = self.provider.generate(full_prompt, params)
@@ -166,19 +155,9 @@ class RAGAgent:
             raise Exception(f"Error generating response with custom prompt: {str(e)}")
 
     def run_chat_completion(self, messages: list,
-                            max_length: int = 1024, truncation: bool = True,
-                            repetition_penalty: float = 1.1, temperature: float = 0.7,
-                            top_p: float = 0.9, top_k: int = 50) -> str:
+                            params: Optional[GenerationParams] = None) -> str:
         """Process chat messages using the provider's chat interface."""
-        params = GenerationParams(
-            max_new_tokens=max_length,
-            truncation=truncation,
-            repetition_penalty=repetition_penalty,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            do_sample=temperature > 0,
-        )
+        params = params or GenerationParams()
 
         try:
             answer = self.provider.chat(messages, params)

--- a/app/ai.py
+++ b/app/ai.py
@@ -1,140 +1,64 @@
-"""
-AI functionality for Sugar-AI, including RAG and LLM components.
-"""
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""RAG and LLM components for Sugar-AI."""
 import os
-import torch
-from transformers import pipeline
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.document_loaders import PyMuPDFLoader, TextLoader
-from langchain_core.runnables import RunnablePassthrough
-from langchain_core.prompts import ChatPromptTemplate
-from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from typing import Optional, List
 import app.prompts as prompts
 from app.config import settings
+from app.providers.base import BaseProvider, GenerationParams
 import logging
+
 logger = logging.getLogger("sugar-ai")
+
 
 def format_docs(docs):
     """Return document content separated by newlines"""
     return "\n\n".join(doc.page_content for doc in docs)
 
-def combine_messages(x):
-    """Combine message content with newlines"""
-    if hasattr(x, "to_messages"):
-        return "\n".join(msg.content for msg in x.to_messages())
-    return str(x)
-
-def extract_answer_from_output(outputs):
-    """Extract the answer text from model output safely."""
-    if not outputs:
-        return ""
-
-    first = outputs[0] or {}
-    generated_text = first.get("generated_text")
-    if not isinstance(generated_text, str):
-        return ""
-
-    if "Child-friendly answer:" in generated_text:
-        return generated_text.split("Child-friendly answer:")[-1].strip()
-
-    if "Answer:" in generated_text:
-        return generated_text.split("Answer:")[-1].strip()
-
-    # Fallback: return the full generated text trimmed.
-    return generated_text.strip()
-
 
 class RAGAgent:
-    """Retrieval-Augmented Generation agent for Sugar-AI"""
-      
-    def __init__(self, model: Optional[str] = None, quantize: bool = True):
-        # 1) Determine model name with clear precedence:
-        #    explicit argument > DEV_MODEL_NAME (if DEV_MODE) > PROD_MODEL_NAME > DEFAULT_MODEL
-        if model:
-            self.model_name = model
-            logger.info("Using explicit model argument: %s", self.model_name)
-        else:
-            if getattr(settings, "DEV_MODE", False):
-                # prefer DEV_MODEL_NAME, then fallback to DEFAULT_MODEL
-                self.model_name = getattr(settings, "DEV_MODEL_NAME", settings.DEFAULT_MODEL)
-                logger.info("DEV_MODE active: using lightweight model %s", self.model_name)
-            else:
-                # production: prefer PROD_MODEL_NAME, else DEFAULT_MODEL
-                self.model_name = getattr(settings, "PROD_MODEL_NAME", settings.DEFAULT_MODEL)
-                logger.info("Using production model %s", self.model_name)
+    """Retrieval-Augmented Generation agent for Sugar-AI.
 
-        # 2) Compute quantization/device choices. Keep quantization off in DEV_MODE by default.
-        self.use_quant = quantize and torch.cuda.is_available() and not getattr(settings, "DEV_MODE", False)
-        device = 0 if torch.cuda.is_available() and not getattr(settings, "DEV_MODE", False) else -1
-        dtype = torch.float16 if device == 0 else torch.float32
+    This class handles document retrieval and prompt orchestration,
+    delegating model loading and inference to a BaseProvider.
+    """
 
-        if self.use_quant:
-            bnb_config = BitsAndBytesConfig(
-                load_in_4bit=True,
-                bnb_4bit_compute_dtype=torch.float16,
-                bnb_4bit_use_double_quant=True,
-                bnb_4bit_quant_type="nf4"
-            )
-
-            tokenizer = AutoTokenizer.from_pretrained(self.model_name)
-            model_obj = AutoModelForCausalLM.from_pretrained(
-                self.model_name,
-                quantization_config=bnb_config,
-                torch_dtype=torch.float16,
-                device_map="auto"
-            )
-            self.model = pipeline(
-                "text-generation",
-                model=model_obj,
-                tokenizer=tokenizer,
-                max_new_tokens=1024,
-                truncation=True,
-            )
-            
-            self.simplify_model = pipeline(
-                "text-generation",
-                model=model_obj,
-                tokenizer=tokenizer,
-                max_new_tokens=1024,
-                truncation=True,
-            )
-        else:
-            self.model = pipeline(
-                "text-generation",
-                model=self.model_name,
-                max_new_tokens=1024,
-                truncation=True,
-                torch_dtype=dtype, # Use the dynamic dtype
-                device=device,     # Use the dynamic device
-            )
-
-            self.simplify_model = self.model
-
+    def __init__(self, provider: BaseProvider):
+        """Initialize RAGAgent with a provider."""
+        self.provider = provider
+        self.model_name = provider.get_model_name()
         self.retriever: Optional[FAISS] = None
-        self.prompt = ChatPromptTemplate.from_template(prompts.PROMPT_TEMPLATE)
-        self.child_prompt = ChatPromptTemplate.from_template(prompts.CHILD_FRIENDLY_PROMPT)
-        self.debug_prompt = ChatPromptTemplate.from_template(prompts.CODE_DEBUG_PROMPT)
-        self.context_prompt = ChatPromptTemplate.from_template(prompts.CODE_CONTEXT_PROMPT)
-        self.kids_debug_prompt = ChatPromptTemplate.from_template(prompts.KIDS_DEBUG_PROMPT)
-        self.kids_context_prompt = ChatPromptTemplate.from_template(prompts.KIDS_CONTEXT_PROMPT)
 
-    def set_model(self, model: str) -> None:
-        """Update the model used by the agent"""
-        self.model_name = model
-        self.model = pipeline(
-            "text-generation",
-            model=self.model_name,
-            max_length=1024,
-            truncation=True,
-            torch_dtype=torch.float16
-        )
-        
-        self.simplify_model = self.model
+        self.prompt_template = prompts.PROMPT_TEMPLATE
+        self.child_prompt_template = prompts.CHILD_FRIENDLY_PROMPT
+        self.debug_prompt_template = prompts.CODE_DEBUG_PROMPT
+        self.context_prompt_template = prompts.CODE_CONTEXT_PROMPT
+        self.kids_debug_prompt_template = prompts.KIDS_DEBUG_PROMPT
+        self.kids_context_prompt_template = prompts.KIDS_CONTEXT_PROMPT
+
+    def set_model(self, provider: BaseProvider) -> None:
+        """Update the current provider."""
+        self.provider = provider
+        self.model_name = provider.get_model_name()
 
     def setup_vectorstore(self, file_paths: List[str]) -> Optional[FAISS]:
-        """Load documents and create a vector store for retrieval"""
+        """Load documents and create a vector store for retrieval."""
         all_documents = []
         for file_path in file_paths:
             if os.path.exists(file_path):
@@ -144,17 +68,17 @@ class RAGAgent:
                     loader = TextLoader(file_path)
                 documents = loader.load()
                 all_documents.extend(documents)
-        
+
         embeddings = HuggingFaceEmbeddings(
             model_name="sentence-transformers/all-MiniLM-L6-v2"
         )
-        
+
         vector_store = FAISS.from_documents(all_documents, embeddings)
         self.retriever = vector_store.as_retriever()
         return self.retriever
 
     def get_relevant_document(self, query: str, threshold: float = 0.5):
-        """Get the most relevant document for a query"""
+        """Get the most relevant document for a query."""
         results = self.retriever.invoke(query)
         if results:
             top_result = results[0]
@@ -162,239 +86,102 @@ class RAGAgent:
             if score >= threshold:
                 return top_result, score
         return None, 0.0
-    
-    def debug(self, code: str, context: bool) -> str:
-        """
-        Debugging chain (dual-chain):
-        Chain 1 - Debugging suggestion: code → debug prompt → combine → model → extract answer
-        Chain 2 - Kid friendly formatting: answer → kids_debug prompt → combine → model → extract answer
-        """
-        debug_chain = (
-            self.debug_prompt
-            | combine_messages
-            | self.model
-            | extract_answer_from_output
-            | self.kids_debug_prompt
-            | combine_messages
-            | self.model
-            | extract_answer_from_output
-        )
-        
-        """
-        Contextualization chain (dual-chain):
-        Chain 1 - Context generation: code → context prompt → combine → model → extract answer
-        Chain 2 - Kid friendly formatting: answer → kids_context prompt → combine → model → extract answer
-        """
-        context_chain = (
-            self.context_prompt
-            | combine_messages
-            | self.model
-            | extract_answer_from_output
-            | self.kids_context_prompt
-            | combine_messages
-            | self.model
-            | extract_answer_from_output
-        )
 
+    def debug(self, code: str, context: bool) -> str:
+        """Debug or explain python code using provider."""
         if context:
-            context_response = context_chain.invoke({"code": code})
-            return context_response
-    
-        debug_response = debug_chain.invoke({"code": code})
-        return debug_response
+            context_prompt = self.context_prompt_template.format(code=code)
+            raw_context = self.provider.generate(context_prompt)
+
+            kids_prompt = self.kids_context_prompt_template.format(context_output=raw_context)
+            kid_friendly = self.provider.generate(kids_prompt)
+            return kid_friendly
+        else:
+            debug_prompt = self.debug_prompt_template.format(code=code)
+            raw_debug = self.provider.generate(debug_prompt)
+
+            kids_prompt = self.kids_debug_prompt_template.format(debug_output=raw_debug)
+            kid_friendly = self.provider.generate(kids_prompt)
+            return kid_friendly
 
     def run(self, question: str) -> str:
-        """Process a question through the RAG pipeline"""
-        # build chain components
-        chain_input = {
-            "context": self.retriever | format_docs,
-            "question": RunnablePassthrough()
-        }
-        
-        # first chain: prompt -> combine messages -> model -> extract answer
-        first_chain = (
-            chain_input
-            | self.prompt
-            | combine_messages
-            | self.model
-            | extract_answer_from_output
-        )
-        
+        """Process a question through the RAG pipeline."""
         doc_result, _ = self.get_relevant_document(question)
         if doc_result:
-            first_response = first_chain.invoke({
-                "query": question,
-                "context": doc_result.page_content
-            })
+            prompt = self.prompt_template.format(
+                question=question,
+                context=doc_result.page_content
+            )
         else:
-            first_response = first_chain.invoke(question)
+            prompt = self.prompt_template.format(
+                question=question,
+                context="No relevant documentation found."
+            )
 
-        # second chain for making answer child-friendly
-        second_chain = (
-            {"original_answer": lambda x: x}
-            | self.child_prompt
-            | combine_messages
-            | self.simplify_model
-            | extract_answer_from_output
-        )
-        
-        final_response = second_chain.invoke(first_response)
+        first_response = self.provider.generate(prompt)
+
+        if "Child-friendly answer:" in first_response:
+            first_response = first_response.split("Child-friendly answer:")[-1].strip()
+        elif "Answer:" in first_response:
+            first_response = first_response.split("Answer:")[-1].strip()
+
+        child_prompt = self.child_prompt_template.format(original_answer=first_response)
+        final_response = self.provider.generate(child_prompt)
+
+        if "Child-friendly answer:" in final_response:
+            final_response = final_response.split("Child-friendly answer:")[-1].strip()
+
         return final_response
 
-    def run_with_custom_prompt(self, question: str, custom_prompt: str, 
-                             max_length: int = 1024, truncation: bool = True,
-                             repetition_penalty: float = 1.1, temperature: float = 0.7,
-                             top_p: float = 0.9, top_k: int = 50) -> str:
-        """Process a question with custom prompt and generation parameters (no RAG)"""
-        
-        # Combine custom prompt with question
+    def run_with_custom_prompt(self, question: str, custom_prompt: str,
+                               max_length: int = 1024, truncation: bool = True,
+                               repetition_penalty: float = 1.1, temperature: float = 0.7,
+                               top_p: float = 0.9, top_k: int = 50) -> str:
+        """Process a question with custom prompt and parameters (no RAG)."""
         full_prompt = f"{custom_prompt}\n\nQuestion: {question}\nAnswer:"
-        
-        # Generate response with custom parameters
+
+        params = GenerationParams(
+            max_new_tokens=max_length,
+            truncation=truncation,
+            repetition_penalty=repetition_penalty,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            do_sample=temperature > 0,
+        )
+
         try:
-            response = self.model(
-                full_prompt,
-                max_length=max_length,
-                truncation=truncation,
-                repetition_penalty=repetition_penalty,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                do_sample=True if temperature > 0 else False,
-                pad_token_id=self.model.tokenizer.eos_token_id,
-            )
-            
-            # Extract the answer from the generated text
-            generated_text = response[0]['generated_text']
-            
-            # Remove the original prompt from the response
-            if "Answer:" in generated_text:
-                answer = generated_text.split("Answer:")[-1].strip()
-            else:
-                # Fallback: remove the input prompt
-                answer = generated_text.replace(full_prompt, "").strip()
-            
-            # Stop at double newlines - this is our main stopping condition, else model continues with generating next user input, which we don't want
+            answer = self.provider.generate(full_prompt, params)
+
+            if "Answer:" in answer:
+                answer = answer.split("Answer:")[-1].strip()
+
             if "\n\n" in answer:
-                # Find the first occurrence of double newlines and cut there
                 double_newline_pos = answer.find("\n\n")
                 answer = answer[:double_newline_pos].strip()
-            
+
             return answer
-            
+
         except Exception as e:
             raise Exception(f"Error generating response with custom prompt: {str(e)}")
 
-    def _normalize_chat_messages(self, messages: list[dict]) -> list[dict]:
-        """
-        Normalize messages to roles expected by Gemma chat template.
-        - Convert 'assistant' -> 'model'
-        - Handle system message placement based on first non-system message:
-        * If first message is 'user': merge system into first user message
-        * If first message is 'assistant': create user message with system content, then assistant message
-        """
-        # Extract system content
-        system_content = ""
-        for msg in messages:
-            if msg.get("role") == "system" and msg.get("content"):
-                system_content = msg["content"]
-                break
-        
-        # Filter out system messages and find first non-system message
-        non_system_messages = [msg for msg in messages if msg.get("role") != "system"]
-        
-        if not non_system_messages:
-            return []
-        
-        normalized = []
-        first_role = non_system_messages[0].get("role")
-        
-        # If first message is assistant and we have system content, add system as user message
-        if first_role == "assistant" and system_content:
-            normalized.append({"role": "user", "content": system_content})
-        
-        # Process all non-system messages
-        for i, msg in enumerate(non_system_messages):
-            role = msg.get("role")
-            content = msg.get("content", "")
-
-            # Convert assistant to model only for Gemma-style chat templates
-            if role == "assistant" and "gemma" in str(self.model_name).lower():
-                role = "model"
-            
-            # Merge system into first user message (if first message is user)
-            if role == "user" and i == 0 and first_role == "user" and system_content:
-                content = f"{system_content}\n\n{content}"
-            
-            normalized.append({"role": role, "content": content})
-        
-        return normalized
-
-
-    def _extract_after_prompt(self, full_text: str, prompt: str, eos_token: str = None) -> str:
-        """
-        Return the model's generated output that follows the input prompt.
-        Keeps logic minimal; optionally trims at eos token or first blank paragraph.
-        """
-        # Remove prompt prefix if present
-        if full_text.startswith(prompt):
-            answer = full_text[len(prompt):].strip()
-        else:
-            answer = full_text.strip()
-
-        # Trim on EOS token if available
-        if eos_token and eos_token in answer:
-            answer = answer.split(eos_token)[0].strip()
-
-        # Conservative stop at first double newline if very long
-        if "\n\n" in answer:
-            candidate = answer.split("\n\n", 1)[0].strip()
-            if len(candidate) > 10:
-                answer = candidate
-        return answer
-
-
-    def run_chat_completion(self, messages: list, 
-                        max_length: int = 1024, truncation: bool = True,
-                        repetition_penalty: float = 1.1, temperature: float = 0.7,
-                        top_p: float = 0.9, top_k: int = 50) -> str:
-        """
-        Process chat messages with chat template format and generation parameters.
-        """
-
-        # Normalize messages and build prompt using tokenizer's chat template
-        chat = self._normalize_chat_messages(messages)
-        full_prompt = self.model.tokenizer.apply_chat_template(
-            chat,
-            tokenize=False,
-            add_generation_prompt=True,
+    def run_chat_completion(self, messages: list,
+                            max_length: int = 1024, truncation: bool = True,
+                            repetition_penalty: float = 1.1, temperature: float = 0.7,
+                            top_p: float = 0.9, top_k: int = 50) -> str:
+        """Process chat messages using the provider's chat interface."""
+        params = GenerationParams(
+            max_new_tokens=max_length,
+            truncation=truncation,
+            repetition_penalty=repetition_penalty,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            do_sample=temperature > 0,
         )
 
-        # Generate response with custom parameters
         try:
-            response = self.model(
-                full_prompt,
-                max_length=max_length,
-                truncation=truncation,
-                repetition_penalty=repetition_penalty,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                do_sample=True if temperature > 0 else False,
-                pad_token_id=self.model.tokenizer.eos_token_id,
-            )
-            
-            # Extract the answer from the generated text
-            generated_text = response[0]['generated_text']
-            
-            # Extract only the new model response
-            answer = self._extract_after_prompt(
-                generated_text,
-                full_prompt,
-                getattr(self.model.tokenizer, "eos_token", None),
-            )
-            
+            answer = self.provider.chat(messages, params)
             return answer
-            
         except Exception as e:
             raise Exception(f"Error generating chat completion: {str(e)}")

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -11,6 +11,9 @@ You are a highly intelligent Python coding assistant built for kids using the Su
 5. Always include Sugar-specific guidance when relevant to the question.
 6. Always answer in English only.
 
+Context from documentation:
+{context}
+
 Question: {question}
 Answer:
 """

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Provider package for Sugar-AI.
+
+Providers are the abstraction layer between RAGAgent and model backends.
+"""
+from app.providers.base import BaseProvider, GenerationParams
+
+__all__ = ["BaseProvider", "GenerationParams"]

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -20,5 +20,7 @@ Provider package for Sugar-AI.
 Providers are the abstraction layer between RAGAgent and model backends.
 """
 from app.providers.base import BaseProvider, GenerationParams
+from app.providers.huggingface import HuggingFaceProvider
 
-__all__ = ["BaseProvider", "GenerationParams"]
+__all__ = ["BaseProvider", "GenerationParams", "HuggingFaceProvider"]
+

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass
+@dataclass(frozen=True)
 class GenerationParams:
     """Parameters controlling text generation behavior."""
     max_new_tokens: int = 1024
@@ -30,6 +30,9 @@ class GenerationParams:
     repetition_penalty: float = 1.1
     truncation: bool = True
     do_sample: bool = True
+
+    def __post_init__(self):
+        object.__setattr__(self, "do_sample", self.temperature > 0)
 
 
 class BaseProvider(ABC):

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Base provider interface for Sugar-AI."""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class GenerationParams:
+    """Parameters controlling text generation behavior."""
+    max_new_tokens: int = 1024
+    temperature: float = 0.7
+    top_p: float = 0.9
+    top_k: int = 50
+    repetition_penalty: float = 1.1
+    truncation: bool = True
+    do_sample: bool = True
+
+
+class BaseProvider(ABC):
+    """Abstract base class for all model providers."""
+
+    @abstractmethod
+    def generate(self, prompt: str, params: Optional[GenerationParams] = None) -> str:
+        ...
+
+    @abstractmethod
+    def chat(self, messages: list[dict], params: Optional[GenerationParams] = None) -> str:
+        ...
+
+    @abstractmethod
+    def get_model_name(self) -> str:
+        ...
+
+    @abstractmethod
+    def health_check(self) -> bool:
+        ...
+

--- a/app/providers/huggingface.py
+++ b/app/providers/huggingface.py
@@ -1,0 +1,188 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""HuggingFace Transformers provider for Sugar-AI."""
+import torch
+from transformers import pipeline, AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+import logging
+from typing import Optional
+
+from app.providers.base import BaseProvider, GenerationParams
+
+logger = logging.getLogger("sugar-ai")
+
+
+class HuggingFaceProvider(BaseProvider):
+    """Provider running HuggingFace models locally via transformers."""
+
+    def __init__(self, model_name: str, quantize: bool = True, dev_mode: bool = False):
+        """Load a HuggingFace model into memory."""
+        self.model_name = model_name
+        self._dev_mode = dev_mode
+
+        use_quant = quantize and torch.cuda.is_available() and not dev_mode
+        device = 0 if torch.cuda.is_available() and not dev_mode else -1
+        dtype = torch.float16 if device == 0 else torch.float32
+
+        if use_quant:
+            bnb_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_compute_dtype=torch.float16,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4"
+            )
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            model_obj = AutoModelForCausalLM.from_pretrained(
+                model_name,
+                quantization_config=bnb_config,
+                torch_dtype=torch.float16,
+                device_map="auto"
+            )
+            self._pipeline = pipeline(
+                "text-generation",
+                model=model_obj,
+                tokenizer=tokenizer,
+                max_new_tokens=1024,
+                truncation=True,
+            )
+        else:
+            self._pipeline = pipeline(
+                "text-generation",
+                model=model_name,
+                max_new_tokens=1024,
+                truncation=True,
+                torch_dtype=dtype,
+                device=device,
+            )
+
+        logger.info("HuggingFaceProvider loaded model: %s (quantized=%s, device=%s)",
+                    model_name, use_quant, device)
+
+    def generate(self, prompt: str, params: Optional[GenerationParams] = None) -> str:
+        """Generate text from a plain string prompt."""
+        if params is None:
+            params = GenerationParams()
+
+        response = self._pipeline(
+            prompt,
+            max_new_tokens=params.max_new_tokens,
+            truncation=params.truncation,
+            repetition_penalty=params.repetition_penalty,
+            temperature=params.temperature,
+            top_p=params.top_p,
+            top_k=params.top_k,
+            do_sample=params.do_sample,
+            pad_token_id=self._pipeline.tokenizer.eos_token_id,
+        )
+
+        generated_text = response[0].get("generated_text", "")
+        if isinstance(generated_text, str) and generated_text.startswith(prompt):
+            generated_text = generated_text[len(prompt):].strip()
+
+        return generated_text
+
+    def chat(self, messages: list[dict], params: Optional[GenerationParams] = None) -> str:
+        """Generate response from chat messages."""
+        if params is None:
+            params = GenerationParams()
+
+        normalized = self._normalize_chat_messages(messages)
+        full_prompt = self._pipeline.tokenizer.apply_chat_template(
+            normalized,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+        response = self._pipeline(
+            full_prompt,
+            max_new_tokens=params.max_new_tokens,
+            truncation=params.truncation,
+            repetition_penalty=params.repetition_penalty,
+            temperature=params.temperature,
+            top_p=params.top_p,
+            top_k=params.top_k,
+            do_sample=params.do_sample,
+            pad_token_id=self._pipeline.tokenizer.eos_token_id,
+        )
+
+        generated_text = response[0].get("generated_text", "")
+        answer = self._extract_after_prompt(
+            generated_text,
+            full_prompt,
+            getattr(self._pipeline.tokenizer, "eos_token", None),
+        )
+
+        return answer
+
+    def get_model_name(self) -> str:
+        return self.model_name
+
+    def health_check(self) -> bool:
+        """Check if pipeline can generate text."""
+        try:
+            result = self._pipeline("test", max_new_tokens=1)
+            return result is not None
+        except Exception:
+            return False
+
+    def _normalize_chat_messages(self, messages: list[dict]) -> list[dict]:
+        """Normalize messages for model-specific requirements."""
+        system_content = ""
+        for msg in messages:
+            if msg.get("role") == "system" and msg.get("content"):
+                system_content = msg["content"]
+                break
+
+        non_system_messages = [msg for msg in messages if msg.get("role") != "system"]
+        if not non_system_messages:
+            return []
+
+        normalized = []
+        first_role = non_system_messages[0].get("role")
+
+        if first_role == "assistant" and system_content:
+            normalized.append({"role": "user", "content": system_content})
+
+        for i, msg in enumerate(non_system_messages):
+            role = msg.get("role")
+            content = msg.get("content", "")
+
+            if role == "assistant" and "gemma" in self.model_name.lower():
+                role = "model"
+
+            if role == "user" and i == 0 and first_role == "user" and system_content:
+                content = f"{system_content}\n\n{content}"
+
+            normalized.append({"role": role, "content": content})
+
+        return normalized
+
+    def _extract_after_prompt(self, full_text: str, prompt: str, eos_token: str = None) -> str:
+        """Extract the model response, removing the echoed prompt."""
+        if full_text.startswith(prompt):
+            answer = full_text[len(prompt):].strip()
+        else:
+            answer = full_text.strip()
+
+        if eos_token and eos_token in answer:
+            answer = answer.split(eos_token)[0].strip()
+
+        if "\n\n" in answer:
+            candidate = answer.split("\n\n", 1)[0].strip()
+            if len(candidate) > 10:
+                answer = candidate
+
+        return answer

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -184,15 +184,19 @@ async def ask_llm_prompted(
             # Convert Pydantic messages to dict format for the agent function
             messages_dict = [{"role": msg.role, "content": msg.content} for msg in request_data.messages]
             
-            # Call the agent's chat completion function
-            answer = agent.run_chat_completion(
-                messages=messages_dict,
-                max_length=request_data.max_length,
-                truncation=request_data.truncation,
-                repetition_penalty=request_data.repetition_penalty,
+            # Build generation params from request
+            params = GenerationParams(
+                max_new_tokens=request_data.max_length,
                 temperature=request_data.temperature,
                 top_p=request_data.top_p,
-                top_k=request_data.top_k
+                top_k=request_data.top_k,
+                repetition_penalty=request_data.repetition_penalty,
+                truncation=request_data.truncation,
+            )
+
+            answer = agent.run_chat_completion(
+                messages=messages_dict,
+                params=params,
             )
             
             process_time = time.time() - start_time
@@ -227,15 +231,19 @@ async def ask_llm_prompted(
             logger.info(f"REQUEST - /ask-llm-prompted - User: {user_info['name']} - IP: {client_ip} - Question: {request_data.question[:200]}...")
             logger.info(f"CUSTOM PROMPT - User: {user_info['name']} - Prompt: {request_data.custom_prompt[:100]}...")
             
+            params = GenerationParams(
+                max_new_tokens=request_data.max_length,
+                temperature=request_data.temperature,
+                top_p=request_data.top_p,
+                top_k=request_data.top_k,
+                repetition_penalty=request_data.repetition_penalty,
+                truncation=request_data.truncation,
+            )
+
             answer = agent.run_with_custom_prompt(
                 question=request_data.question,
                 custom_prompt=request_data.custom_prompt,
-                max_length=request_data.max_length,
-                truncation=request_data.truncation,
-                repetition_penalty=request_data.repetition_penalty,
-                temperature=request_data.temperature,
-                top_p=request_data.top_p,
-                top_k=request_data.top_k
+                params=params,
             )
             
             process_time = time.time() - start_time

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -12,7 +12,8 @@ from datetime import datetime
 from typing import Dict, Optional, List
 
 from app.database import get_db, APIKey
-from app.ai import RAGAgent, extract_answer_from_output
+from app.ai import RAGAgent
+from app.providers.base import GenerationParams
 from app.config import settings
 
 # Pydantic models for chat completions
@@ -130,8 +131,7 @@ async def ask_llm(
     logger.info(f"REQUEST - /ask-llm - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
     
     try:
-        response = agent.model(question)
-        answer = extract_answer_from_output(response)
+        answer = agent.provider.generate(question)
         
         process_time = time.time() - start_time
         logger.info(f"RESPONSE - User: {user_info['name']} - Success - Time: {process_time:.2f}s")
@@ -320,7 +320,13 @@ async def change_model(
         raise HTTPException(status_code=403, detail="Invalid model change password")
     
     try:
-        agent.set_model(model)
+        from app.providers import HuggingFaceProvider
+        new_provider = HuggingFaceProvider(
+            model_name=model,
+            quantize=True,
+            dev_mode=False,
+        )
+        agent.set_model(new_provider)
         logger.info(f"Model changed to {model} by {user_info['name']}")
         return {"message": f"Model changed to {model}", "user": user_info["name"]}
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ import os
 
 from app import create_app
 from app.ai import RAGAgent
+from app.providers import HuggingFaceProvider
 from app.database import get_db
 from app.auth import sync_env_keys_to_db
 from app.config import settings
@@ -47,13 +48,19 @@ async def startup_event():
         active_model = settings.PROD_MODEL_NAME
         logger.info(f"PRODUCTION mode. Loading full model: {active_model}")
 
-    initialized_agent = RAGAgent(model=active_model)
+    # Create provider first, then pass it to RAGAgent
+    provider = HuggingFaceProvider(
+        model_name=active_model,
+        quantize=True,
+        dev_mode=settings.DEV_MODE,
+    )
+
+    initialized_agent = RAGAgent(provider=provider)
     initialized_agent.retriever = initialized_agent.setup_vectorstore(settings.DOC_PATHS)
 
     # Inject this instance into the API module
-    # This updates the 'agent = None' in api.py to be the real loaded model
     api.agent = initialized_agent
-    
+
     app.state.agent = initialized_agent
 
 
@@ -61,4 +68,3 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", 8000))
     logger.info(f"Starting Sugar-AI on port {port}")
     uvicorn.run(app, host="0.0.0.0", port=port)
-


### PR DESCRIPTION
## Summary

Extracts all HuggingFace-specific code from `RAGAgent` into a standalone `HuggingFaceProvider` class behind an abstract `BaseProvider` interface.

## Changes

### New files
- `app/providers/base.py`  :  `BaseProvider` ABC + `GenerationParams` dataclass
- `app/providers/huggingface.py`  :  `HuggingFaceProvider` (all HF logic extracted here)
- `app/providers/__init__.py`  :  Package init

### Modified files
- `app/ai.py` : RAGAgent now accepts `BaseProvider`, no torch/transformers imports
- `main.py` : Creates `HuggingFaceProvider` and passes it to `RAGAgent` on startup
- `app/routes/api.py` :  `/ask-llm` uses `agent.provider.generate()`, `/change-model` creates a new provider instance

## Why

`RAGAgent` was tightly coupled to the HuggingFace pipeline. This made it impossible to swap in other backends (Ollama, OpenAI-compatible, Gemini). After this refactor, adding a new provider only requires implementing `BaseProvider`   `RAGAgent` and all routes work without modification.

## Testing

All endpoints manually tested with SmolLM-135M in DEV_MODE:
- [x] `POST /ask` 
- [x] `POST /ask-llm`  
-  [x] `POST /ask-llm-prompted` (custom prompt) 
-  [x] `POST /ask-llm-prompted` (chat mode) 
-  [x] `POST /debug` 
