### PR TITLE
Feature/think nothink 

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -15,6 +15,8 @@ AI_PROVIDER=huggingface
 
 # For Ollama, change AI_PROVIDER to ollama and uncomment these lines.
 # AI_MODEL can be any model installed on your Ollama server.
+# A reasoning-capable model (e.g. qwen3.5) also enables the opt-in `think`
+# flag on every generation endpoint (default off); see README Reasoning section.
 # AI_MODEL=qwen3.5:1.5b
 # OLLAMA_BASE_URL=http://localhost:11434
 
@@ -44,6 +46,11 @@ DOC_PATHS=["./docs/Pygame Documentation.pdf", "./docs/Python GTK+3 Documentation
 PORT=8000
 
 MAX_DAILY_REQUESTS=100
+
+# Extra output tokens granted when reasoning (think=true) is requested, so the
+# chain-of-thought does not eat into the answer's token budget. Tune per model
+# (larger models need less). Applies on any endpoint when think=true.
+THINKING_HEADROOM=2048
 
 # OAuth Configuration
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Sugar-AI provides three different endpoints for different use cases:
         "repetition_penalty": 1.1,
         "temperature": 0.7,
         "top_p": 0.9,
-        "top_k": 50
+        "top_k": 50,
+        "think": false
       }'
     ```
 
@@ -171,7 +172,8 @@ Sugar-AI provides three different endpoints for different use cases:
         "max_length": 512,
         "temperature": 0.6,
         "top_p": 0.9,
-        "top_k": 50
+        "top_k": 50,
+        "think": false
       }'
     ```
     - Send chat history with roles `system`, `user`, and `assistant`.
@@ -188,6 +190,7 @@ Sugar-AI provides three different endpoints for different use cases:
     - `temperature` (optional, default: 0.7): Controls randomness (0.0 = deterministic, 1.0 = very random)
     - `top_p` (optional, default: 0.9): Nucleus sampling (0.1 = focused, 0.9 = diverse)
     - `top_k` (optional, default: 50): Limits vocabulary to K most likely words
+    - `think` (optional, default: false): Enable model reasoning for this request. See [Reasoning (think / no-think)](#reasoning-think--no-think) below.
 
     **Response Format (Prompted mode):**
     ```json
@@ -201,7 +204,8 @@ Sugar-AI provides three different endpoints for different use cases:
         "repetition_penalty": 1.1,
         "temperature": 0.7,
         "top_p": 0.9,
-        "top_k": 50
+        "top_k": 50,
+        "think": false
       }
     }
     ```
@@ -227,7 +231,8 @@ Sugar-AI provides three different endpoints for different use cases:
         "repetition_penalty": 1.1,
         "temperature": 0.6,
         "top_p": 0.9,
-        "top_k": 50
+        "top_k": 50,
+        "think": false
       }
     }
     ```
@@ -247,6 +252,37 @@ Sugar-AI provides three different endpoints for different use cases:
     - **For Code**: `temperature: 0.2-0.4, top_p: 0.8, repetition_penalty: 1.1`
     - **For Creative Content**: `temperature: 0.7-0.9, top_p: 0.9, repetition_penalty: 1.2`
     - **For Factual Answers**: `temperature: 0.3-0.5, top_p: 0.7, repetition_penalty: 1.0`
+
+### Reasoning (think / no-think)
+
+Reasoning-capable models can spend extra tokens on reasoning before answering. This can help multi-step tasks, but it costs extra latency and tokens. Sugar-AI keeps reasoning off by default on every endpoint and exposes it as an opt-in `think` flag.
+
+`think` is accepted on all generation endpoints. On `/ask`, `/ask-llm`, and `/debug`, it is a query flag. On `/ask-llm-prompted`, it goes in the JSON body alongside the other generation parameters. If callers omit it, the endpoint behaves as before with no-think.
+
+```sh
+# simple endpoint: think is a query flag
+curl -X POST "http://localhost:8000/ask-llm?question=Explain%20recursion&think=true" \
+  -H "X-API-Key: sugarai2024"
+
+# prompted endpoint: think goes in the JSON body
+curl -X POST "http://localhost:8000/ask-llm-prompted" \
+  -H "X-API-Key: sugarai2024" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "Refactor this recursive function to be iterative and explain the tradeoffs.",
+    "custom_prompt": "You are a senior Python mentor.",
+    "think": true,
+    "max_length": 1024
+  }'
+```
+
+Things to know:
+- Default is no-think everywhere. Existing callers that omit `think` are unaffected.
+- On `/ask` and `/debug`, `think=true` applies to the first answer or analysis stage only. The child-friendly rewrite stage always runs no-think.
+- Ollama is the only provider that honors `think` today. The OpenAI-compatible base provider, Gemini, and HuggingFace currently ignore it.
+- Some Ollama models reject the `think` field. Sugar-AI retries once without `think` so those models can still return an answer.
+- Model behavior is capability dependent. Pure reasoning or reasoning-style models may still include reasoning text even when `think=false`.
+- Reasoning shares the output token budget with the answer, so Sugar-AI adds `THINKING_HEADROOM` tokens when `think=true`. The default is 2048 and can be changed in `.env`.
 
 ### API Authentication
 

--- a/app/ai.py
+++ b/app/ai.py
@@ -105,25 +105,34 @@ class RAGAgent:
                 return top_result, score
         return None, 0.0
 
-    def debug(self, code: str, context: bool) -> str:
-        """Debug or explain python code using provider."""
+    def debug(self, code: str, context: bool,
+              params: Optional[GenerationParams] = None) -> str:
+        """Debug or explain python code using provider.
+
+        params (which may enable reasoning) applies to the analysis stage only;
+        the child-friendly rewrite always runs no-think.
+        """
         if context:
             context_prompt = self.context_prompt_template.format(code=code)
-            raw_context = self.provider.generate(context_prompt)
+            raw_context = self.provider.generate(context_prompt, params)
 
             kids_prompt = self.kids_context_prompt_template.format(context_output=raw_context)
             kid_friendly = self.provider.generate(kids_prompt)
             return kid_friendly
         else:
             debug_prompt = self.debug_prompt_template.format(code=code)
-            raw_debug = self.provider.generate(debug_prompt)
+            raw_debug = self.provider.generate(debug_prompt, params)
 
             kids_prompt = self.kids_debug_prompt_template.format(debug_output=raw_debug)
             kid_friendly = self.provider.generate(kids_prompt)
             return kid_friendly
 
-    def run(self, question: str) -> str:
-        """Process a question through the RAG pipeline."""
+    def run(self, question: str, params: Optional[GenerationParams] = None) -> str:
+        """Process a question through the RAG pipeline.
+
+        params (which may enable reasoning) applies to the answer stage only;
+        the child-friendly rewrite always runs no-think.
+        """
         doc_result, _ = self.get_relevant_document(question)
         if doc_result:
             prompt = self.prompt_template.format(
@@ -136,7 +145,7 @@ class RAGAgent:
                 context="No relevant documentation found."
             )
 
-        first_response = self.provider.generate(prompt)
+        first_response = self.provider.generate(prompt, params)
 
         if "Child-friendly answer:" in first_response:
             first_response = first_response.split("Child-friendly answer:")[-1].strip()

--- a/app/config.py
+++ b/app/config.py
@@ -36,7 +36,12 @@ class Settings(BaseSettings):
     # Reasoning shares the output token budget with the answer. When think is on,
     # add this many tokens on top of the caller's max_length so reasoning cannot
     # starve the answer to empty. Tune per model (larger models need less).
-    THINKING_HEADROOM: int = 2048
+    THINKING_HEADROOM: int = Field(
+        2048,
+        ge=0,
+        le=8192,
+        description="Extra output tokens reserved for reasoning",
+    )
 
     # OAuth
     github_client_id: Optional[str] = None

--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,11 @@ class Settings(BaseSettings):
     DOC_PATHS: List[str] = Field(default_factory=list)
     MAX_DAILY_REQUESTS: int = 100
 
+    # Reasoning shares the output token budget with the answer. When think is on,
+    # add this many tokens on top of the caller's max_length so reasoning cannot
+    # starve the answer to empty. Tune per model (larger models need less).
+    THINKING_HEADROOM: int = 2048
+
     # OAuth
     github_client_id: Optional[str] = None
     github_client_secret: Optional[str] = None

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -37,6 +37,9 @@ class GenerationParams:
     repetition_penalty: float = 1.1
     truncation: bool = True
     do_sample: bool = True
+    # Toggle the model's internal chain-of-thought reasoning. Defaults off so simple
+    # queries stay fast and cheap; callers opt in per request when a task needs it.
+    think: Optional[bool] = False
 
     def __post_init__(self):
         object.__setattr__(self, "do_sample", self.temperature > 0)

--- a/app/providers/ollama.py
+++ b/app/providers/ollama.py
@@ -111,21 +111,31 @@ class OllamaProvider(BaseProvider):
         think field, so drop it and retry to return a normal answer instead
         of failing.
         """
-        try:
+        response = self._client.post(f"{self.base_url}{path}", json=payload)
+
+        if "think" in payload and self._is_thinking_unsupported(response):
+            payload.pop("think")
+            logger.warning(
+                "Model %s does not support thinking; retrying without it.",
+                self.model_name,
+            )
             response = self._client.post(f"{self.base_url}{path}", json=payload)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError:
-            if "think" in payload:
-                payload.pop("think")
-                logger.warning(
-                    "Model %s rejected the think flag; retrying without it.",
-                    self.model_name,
-                )
-                response = self._client.post(f"{self.base_url}{path}", json=payload)
-                response.raise_for_status()
-                return response.json()
-            raise
+
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _is_thinking_unsupported(response: httpx.Response) -> bool:
+        """Return whether Ollama rejected the request because think is unsupported."""
+        if response.status_code != httpx.codes.BAD_REQUEST:
+            return False
+
+        try:
+            error = response.json().get("error", "")
+        except (ValueError, AttributeError):
+            return False
+
+        return isinstance(error, str) and "does not support thinking" in error.lower()
 
     def _params_to_options(self, params: GenerationParams) -> dict:
         """Convert GenerationParams to Ollama's options format."""

--- a/app/providers/ollama.py
+++ b/app/providers/ollama.py
@@ -58,14 +58,11 @@ class OllamaProvider(BaseProvider):
             "stream": False,
             "options": self._params_to_options(params),
         }
+        # think is a top-level Ollama field, not part of options.
+        if params.think is not None:
+            payload["think"] = params.think
 
-        response = self._client.post(
-            f"{self.base_url}/api/generate",
-            json=payload,
-        )
-        response.raise_for_status()
-
-        data = response.json()
+        data = self._post_with_think_fallback("/api/generate", payload)
         return data.get("response", "").strip()
 
     def chat(self, messages: list[dict], params: Optional[GenerationParams] = None) -> str:
@@ -79,14 +76,11 @@ class OllamaProvider(BaseProvider):
             "stream": False,
             "options": self._params_to_options(params),
         }
+        # think is a top-level Ollama field, not part of options.
+        if params.think is not None:
+            payload["think"] = params.think
 
-        response = self._client.post(
-            f"{self.base_url}/api/chat",
-            json=payload,
-        )
-        response.raise_for_status()
-
-        data = response.json()
+        data = self._post_with_think_fallback("/api/chat", payload)
         message = data.get("message", {})
         return message.get("content", "").strip()
 
@@ -109,6 +103,29 @@ class OllamaProvider(BaseProvider):
             return response.status_code == 200
         except Exception:
             return False
+
+    def _post_with_think_fallback(self, path: str, payload: dict) -> dict:
+        """POST to Ollama, retrying once without the think flag if it is rejected.
+
+        Models that do not support reasoning reject a request carrying the
+        think field, so drop it and retry to return a normal answer instead
+        of failing.
+        """
+        try:
+            response = self._client.post(f"{self.base_url}{path}", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError:
+            if "think" in payload:
+                payload.pop("think")
+                logger.warning(
+                    "Model %s rejected the think flag; retrying without it.",
+                    self.model_name,
+                )
+                response = self._client.post(f"{self.base_url}{path}", json=payload)
+                response.raise_for_status()
+                return response.json()
+            raise
 
     def _params_to_options(self, params: GenerationParams) -> dict:
         """Convert GenerationParams to Ollama's options format."""

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -48,6 +48,15 @@ agent = None
 # user quotas tracking
 user_quotas: Dict[str, Dict] = {}
 
+def budget_with_headroom(base_max_tokens: int, think: bool) -> int:
+    """Add reasoning headroom to the token budget when think is on.
+
+    Reasoning shares the output token budget with the answer, so without extra
+    room the chain-of-thought can consume it all and starve the answer to empty.
+    """
+    return base_max_tokens + settings.THINKING_HEADROOM if think else base_max_tokens
+
+
 def check_quota(api_key: str) -> bool:
     """Check if a user has exceeded their daily quota"""
     today = datetime.now().date()
@@ -123,18 +132,20 @@ async def ask_question(
 
 @router.post("/ask-llm")
 async def ask_llm(
-    question: str, 
-    user_info: dict = Depends(verify_api_key), 
+    question: str,
+    think: bool = False,
+    user_info: dict = Depends(verify_api_key),
     request: Request = None
 ):
     """Process a question with direct LLM call (no retrieval)"""
     start_time = time.time()
-    
+
     client_ip = request.client.host if request else "unknown"
     logger.info(f"REQUEST - /ask-llm - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
-    
+
     try:
-        answer = agent.provider.generate(question)
+        params = GenerationParams(think=think, max_new_tokens=budget_with_headroom(1024, think))
+        answer = agent.provider.generate(question, params)
         
         process_time = time.time() - start_time
         logger.info(f"RESPONSE - User: {user_info['name']} - Success - Time: {process_time:.2f}s")
@@ -168,11 +179,7 @@ async def ask_llm_prompted(
     api_key = next(key for key, value in settings.API_KEYS.items() if value['name'] == user_info['name'])
     remaining = settings.MAX_DAILY_REQUESTS - user_quotas.get(api_key, {}).get("count", 0)
     
-    # Reasoning shares the output token budget, so give it headroom when enabled
-    # to avoid starving the answer to empty.
-    effective_max_tokens = request_data.max_length
-    if request_data.think:
-        effective_max_tokens += settings.THINKING_HEADROOM
+    effective_max_tokens = budget_with_headroom(request_data.max_length, request_data.think)
 
     try:
         if request_data.chat:

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -27,7 +27,6 @@ class PromptedLLMRequest(BaseModel):
     question: Optional[str] = Field(None, description="The question to ask (required if chat=False)")
     custom_prompt: Optional[str] = Field(None, description="Custom prompt to replace system prompt (required if chat=False)")
     messages: Optional[List[ChatMessage]] = Field(None, description="List of chat messages (required if chat=True)")
-    
     # Boundary validation added below:
     max_length: int = Field(1024, gt=0, le=8192, description="Maximum length of generated text")
     truncation: bool = Field(True, description="Whether to truncate input if too long")

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -35,6 +35,7 @@ class PromptedLLMRequest(BaseModel):
     temperature: float = Field(0.7, ge=0.0, le=2.0, description="Temperature for sampling")
     top_p: float = Field(0.9, gt=0.0, le=1.0, description="Top-p (nucleus) sampling parameter")
     top_k: int = Field(50, ge=0, description="Top-k sampling parameter")
+    think: bool = Field(False, description="Enable model reasoning (Ollama only, defaults off)")
 
 router = APIRouter(tags=["api"])
 
@@ -167,6 +168,12 @@ async def ask_llm_prompted(
     api_key = next(key for key, value in settings.API_KEYS.items() if value['name'] == user_info['name'])
     remaining = settings.MAX_DAILY_REQUESTS - user_quotas.get(api_key, {}).get("count", 0)
     
+    # Reasoning shares the output token budget, so give it headroom when enabled
+    # to avoid starving the answer to empty.
+    effective_max_tokens = request_data.max_length
+    if request_data.think:
+        effective_max_tokens += settings.THINKING_HEADROOM
+
     try:
         if request_data.chat:
             # Chat completions mode
@@ -188,12 +195,13 @@ async def ask_llm_prompted(
             
             # Build generation params from request
             params = GenerationParams(
-                max_new_tokens=request_data.max_length,
+                max_new_tokens=effective_max_tokens,
                 temperature=request_data.temperature,
                 top_p=request_data.top_p,
                 top_k=request_data.top_k,
                 repetition_penalty=request_data.repetition_penalty,
                 truncation=request_data.truncation,
+                think=request_data.think,
             )
 
             answer = agent.run_chat_completion(
@@ -222,7 +230,8 @@ async def ask_llm_prompted(
                     "repetition_penalty": request_data.repetition_penalty,
                     "temperature": request_data.temperature,
                     "top_p": request_data.top_p,
-                    "top_k": request_data.top_k
+                    "top_k": request_data.top_k,
+                    "think": request_data.think
                 }
             }
         else:
@@ -234,12 +243,13 @@ async def ask_llm_prompted(
             logger.info(f"CUSTOM PROMPT - User: {user_info['name']} - Prompt: {request_data.custom_prompt[:100]}...")
             
             params = GenerationParams(
-                max_new_tokens=request_data.max_length,
+                max_new_tokens=effective_max_tokens,
                 temperature=request_data.temperature,
                 top_p=request_data.top_p,
                 top_k=request_data.top_k,
                 repetition_penalty=request_data.repetition_penalty,
                 truncation=request_data.truncation,
+                think=request_data.think,
             )
 
             answer = agent.run_with_custom_prompt(
@@ -261,7 +271,8 @@ async def ask_llm_prompted(
                     "repetition_penalty": request_data.repetition_penalty,
                     "temperature": request_data.temperature,
                     "top_p": request_data.top_p,
-                    "top_k": request_data.top_k
+                    "top_k": request_data.top_k,
+                    "think": request_data.think
                 }
             }
         

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -94,18 +94,20 @@ def verify_api_key(api_key: Optional[str] = Header(None, alias="X-API-Key"), req
 
 @router.post("/ask")
 async def ask_question(
-    question: str, 
-    user_info: dict = Depends(verify_api_key), 
+    question: str,
+    think: bool = False,
+    user_info: dict = Depends(verify_api_key),
     request: Request = None
 ):
     """Process a question using RAG pipeline"""
     start_time = time.time()
-    
+
     client_ip = request.client.host if request else "unknown"
     logger.info(f"REQUEST - /ask - User: {user_info['name']} - IP: {client_ip} - Question: {question[:50]}...")
-    
+
     try:
-        answer = agent.run(question)
+        params = GenerationParams(think=think, max_new_tokens=budget_with_headroom(1024, think))
+        answer = agent.run(question, params)
         
         # log completion
         process_time = time.time() - start_time
@@ -291,19 +293,21 @@ async def ask_llm_prompted(
         
 @router.post("/debug")
 async def debug(
-    code: str, 
+    code: str,
     context: bool,
-    user_info: dict = Depends(verify_api_key), 
+    think: bool = False,
+    user_info: dict = Depends(verify_api_key),
     request: Request = None
 ):
     """Process python code for debugging"""
     start_time = time.time()
-    
+
     client_ip = request.client.host if request else "unknown"
     logger.info(f"REQUEST - /debug - User: {user_info['name']} - IP: {client_ip} - code: {code[:50]}...")
-    
+
     try:
-        response = agent.debug(code, context)
+        params = GenerationParams(think=think, max_new_tokens=budget_with_headroom(1024, think))
+        response = agent.debug(code, context, params)
         answer = response
         
         process_time = time.time() - start_time


### PR DESCRIPTION
## Summary

Adds an opt-in `think` flag for model reasoning control across Sugar-AI generation endpoints.

This keeps no-think as the default behavior, so existing clients that do not send `think` continue working as before.

## Changes

- Added `think` to `GenerationParams`
- Added `THINKING_HEADROOM` config for reasoning token budget headroom
- Passed `think` through:
  - `/ask`
  - `/ask-llm`
  - `/ask-llm-prompted`
  - `/debug`
- Added Ollama support for top-level `think`
- Added Ollama fallback retry when a model rejects the `think` field
- Kept non-Ollama providers compatible by ignoring `think`
- Documented `think` usage in `README.md`
- Documented `THINKING_HEADROOM` in `.example.env`

## Behavior

For Ollama models that support reasoning:

- `think=true` requests reasoning mode
- `think=false` keeps reasoning off by default

For Ollama models that reject the `think` parameter:

- Sugar-AI retries once without `think`
- The request can still return a normal answer instead of failing

For non-Ollama providers:

- The `think` parameter is accepted by Sugar-AI but ignored by the provider layer

## Notes

Model behavior is capability dependent. Some reasoning-style models may still include reasoning text even when `think=false`, because the model itself may not support disabling reasoning.

## Testing

Manual testing covered:

- Hybrid reasoning model: `qwen3.5:0.8b`
- Reasoning-style model: `deepseek-r1:1.5b`
- Model that doesn't support `think` param: `llama3.2:1b `
- Sugar-AI `/health`
- Sugar-AI `/ask-llm`
- Sugar-AI `/ask-llm-prompted`
- Sugar-AI `/debug`
- Direct Ollama `/api/generate`

part of issue https://github.com/sugarlabs/sugar-ai/issues/129
