### PR TITLE
fix: resolve RAG relevance scoring bug and Python 3.9 compatibility

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -93,10 +93,14 @@ class RAGAgent:
 
     def get_relevant_document(self, query: str, threshold: float = 0.5):
         """Get the most relevant document for a query."""
-        results = self.retriever.invoke(query)
+        if not self.retriever:
+            return None, 0.0
+        results = self.retriever.vector_store.similarity_search_with_relevance_scores(
+            query,
+            **self.retriever.search_kwargs
+        )
         if results:
-            top_result = results[0]
-            score = top_result.metadata.get("score", 0.0)
+            top_result, score = results[0]
             if score >= threshold:
                 return top_result, score
         return None, 0.0

--- a/app/ai.py
+++ b/app/ai.py
@@ -95,7 +95,7 @@ class RAGAgent:
         """Get the most relevant document for a query."""
         if not self.retriever:
             return None, 0.0
-        results = self.retriever.vector_store.similarity_search_with_relevance_scores(
+        results = self.retriever.vectorstore.similarity_search_with_relevance_scores(
             query,
             **self.retriever.search_kwargs
         )

--- a/app/config.py
+++ b/app/config.py
@@ -11,21 +11,21 @@ class Settings(BaseSettings):
 
     # Dev mode (THIS MUST EXIST)
     DEV_MODE: bool = os.getenv("DEV_MODE", "0") == "1"
-    DEV_MODEL_NAME: Optional[str] = None
-    PROD_MODEL_NAME: Optional[str] = None
-    DEFAULT_MODEL: Optional[str] = None
+    DEV_MODEL_NAME: str | None = None
+    PROD_MODEL_NAME: str | None = None
+    DEFAULT_MODEL: str | None = None
 
     # Provider selection
     AI_PROVIDER: str = 'huggingface'
-    AI_MODEL: Optional[str] = None
+    AI_MODEL: str | None = None
     OLLAMA_BASE_URL: str = 'http://localhost:11434'
 
     # OpenAI-compatible provider (Groq, Cerebras, OpenRouter, OpenAI, Mistral, ...)
-    OPENAI_API_KEY: Optional[str] = None
+    OPENAI_API_KEY: str | None = None
     OPENAI_BASE_URL: str = 'https://api.openai.com/v1'
 
     # Google Gemini provider
-    GEMINI_API_KEY: Optional[str] = None
+    GEMINI_API_KEY: str | None = None
     GEMINI_BASE_URL: str = 'https://generativelanguage.googleapis.com/v1beta'
 
     API_KEYS: Dict[str, Dict[str, Any]] = Field(default_factory=dict)

--- a/app/config.py
+++ b/app/config.py
@@ -11,21 +11,21 @@ class Settings(BaseSettings):
 
     # Dev mode (THIS MUST EXIST)
     DEV_MODE: bool = os.getenv("DEV_MODE", "0") == "1"
-    DEV_MODEL_NAME: str | None = None
-    PROD_MODEL_NAME: str | None = None
-    DEFAULT_MODEL: str | None = None
+    DEV_MODEL_NAME: Optional[str] = None
+    PROD_MODEL_NAME: Optional[str] = None
+    DEFAULT_MODEL: Optional[str] = None
 
     # Provider selection
     AI_PROVIDER: str = 'huggingface'
-    AI_MODEL: str | None = None
+    AI_MODEL: Optional[str] = None
     OLLAMA_BASE_URL: str = 'http://localhost:11434'
 
     # OpenAI-compatible provider (Groq, Cerebras, OpenRouter, OpenAI, Mistral, ...)
-    OPENAI_API_KEY: str | None = None
+    OPENAI_API_KEY: Optional[str] = None
     OPENAI_BASE_URL: str = 'https://api.openai.com/v1'
 
     # Google Gemini provider
-    GEMINI_API_KEY: str | None = None
+    GEMINI_API_KEY: Optional[str] = None
     GEMINI_BASE_URL: str = 'https://generativelanguage.googleapis.com/v1beta'
 
     API_KEYS: Dict[str, Dict[str, Any]] = Field(default_factory=dict)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import MagicMock
+from langchain_core.documents import Document
+from app.ai import RAGAgent
+
+class TestRAGAgentRelevance(unittest.TestCase):
+    def setUp(self):
+        # Create a mock provider
+        self.mock_provider = MagicMock()
+        self.mock_provider.get_model_name.return_value = "mock-model"
+        self.mock_provider.get_eos_token.return_value = None
+        
+        # Initialize RAGAgent with mock provider
+        self.agent = RAGAgent(provider=self.mock_provider)
+        
+        # Mock retriever and its underlying vector store
+        self.mock_retriever = MagicMock()
+        self.mock_vector_store = MagicMock()
+        self.mock_retriever.vector_store = self.mock_vector_store
+        self.mock_retriever.search_kwargs = {"k": 3}
+        self.agent.retriever = self.mock_retriever
+
+    def test_get_relevant_document_above_threshold(self):
+        # Set up mock search results returning a score above threshold (0.5)
+        doc = Document(page_content="Sugar Labs makes Sugar-AI.", metadata={"source": "test.txt"})
+        self.mock_vector_store.similarity_search_with_relevance_scores.return_value = [
+            (doc, 0.8)
+        ]
+        
+        result_doc, score = self.agent.get_relevant_document("What is Sugar-AI?", threshold=0.5)
+        
+        self.assertIsNotNone(result_doc)
+        self.assertEqual(result_doc.page_content, "Sugar Labs makes Sugar-AI.")
+        self.assertEqual(score, 0.8)
+        self.mock_vector_store.similarity_search_with_relevance_scores.assert_called_once_with(
+            "What is Sugar-AI?",
+            k=3
+        )
+
+    def test_get_relevant_document_below_threshold(self):
+        # Set up mock search results returning a score below threshold
+        doc = Document(page_content="Irrelevant info.", metadata={"source": "test.txt"})
+        self.mock_vector_store.similarity_search_with_relevance_scores.return_value = [
+            (doc, 0.3)
+        ]
+        
+        result_doc, score = self.agent.get_relevant_document("What is Sugar-AI?", threshold=0.5)
+        
+        self.assertIsNone(result_doc)
+        self.assertEqual(score, 0.0)
+
+    def test_get_relevant_document_empty_results(self):
+        # Set up mock search returning empty results
+        self.mock_vector_store.similarity_search_with_relevance_scores.return_value = []
+        
+        result_doc, score = self.agent.get_relevant_document("What is Sugar-AI?", threshold=0.5)
+        
+        self.assertIsNone(result_doc)
+        self.assertEqual(score, 0.0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -16,7 +16,7 @@ class TestRAGAgentRelevance(unittest.TestCase):
         # Mock retriever and its underlying vector store
         self.mock_retriever = MagicMock()
         self.mock_vector_store = MagicMock()
-        self.mock_retriever.vector_store = self.mock_vector_store
+        self.mock_retriever.vectorstore = self.mock_vector_store
         self.mock_retriever.search_kwargs = {"k": 3}
         self.agent.retriever = self.mock_retriever
 


### PR DESCRIPTION
### Description
Fixes a critical logic bug in `RAGAgent.get_relevant_document` that completely prevents the RAG pipeline from retrieving and injecting document context.

### The Issue
Currently, `get_relevant_document` calls `self.retriever.invoke(query)` which retrieves standard `Document` objects from the vector store, but does not populate or include a similarity/relevance score in the document's metadata dictionary. 

As a result:
```python
score = top_result.metadata.get("score", 0.0) # Always evaluates to 0.0
