### PR TITLE
feat: handle context-window overflow with model-aware limits and conversation compression (fixes #120)

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -13,6 +13,10 @@ PROD_MODEL_NAME=Qwen/Qwen2-1.5B-Instruct
 # AI provider (huggingface or ollama)
 AI_PROVIDER=huggingface
 
+# Context window in tokens for providers that do not advertise model metadata.
+# Hugging Face uses the tokenizer limit when available.
+# AI_CONTEXT_WINDOW=4096
+
 # For Ollama, change AI_PROVIDER to ollama and uncomment these lines.
 # AI_MODEL can be any model installed on your Ollama server.
 # AI_MODEL=qwen3.5:1.5b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-test.txt
+      - name: Run tests
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ The container starts by executing `main.py`. To change the startup behavior, upd
 
 The FastAPI server provides endpoints to interact with Sugar-AI.
 
+### Running the regression suite
+
+Install the development dependencies and run the tests with:
+
+```sh
+pip install -r requirements-test.txt
+python -m pytest -q
+```
+
+The same command runs automatically in GitHub Actions for pushes and pull
+requests.
+
+### Context-window handling
+
+Before generation, Sugar-AI reserves space for the requested output and fits
+plain prompts or chat history into the active provider's context window. Older
+chat turns are represented by a deterministic compressed summary, while recent
+turns and system instructions are retained. The frontend can read the active
+limits from `GET /model-metadata`; the backend remains authoritative. Hugging
+Face providers use the tokenizer's advertised limit when available. Other
+providers use `AI_CONTEXT_WINDOW` (default `4096`) when their server does not
+publish model capabilities.
+
+This work supersedes the narrower scope of [PR #131](https://github.com/sugarlabs/sugar-ai/pull/131),
+which remains open and focuses on replacing `max_length` with `max_new_tokens`
+and adding basic chat budgeting. The implementation here retains that output
+token safety while also covering the default Hugging Face path, provider
+tokenizer counting, retrieved RAG context, and frontend metadata.
+
 ### Install dependencies
 
 ```sh

--- a/app/ai.py
+++ b/app/ai.py
@@ -146,6 +146,7 @@ class RAGAgent:
         )
         retrieval_tokens = max(
             1,
+            # Match the per-message framing overhead used by _message_tokens.
             context_budget.input_tokens - self.provider.count_tokens(empty_context_prompt) - 4,
         )
         retrieved_context = fit_text(

--- a/app/ai.py
+++ b/app/ai.py
@@ -20,8 +20,8 @@ from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.document_loaders import PyMuPDFLoader, TextLoader
 from typing import Optional, List
 import app.prompts as prompts
-from app.config import settings
 from app.providers.base import BaseProvider, GenerationParams
+from app.context import ContextBudget, fit_text
 import logging
 
 logger = logging.getLogger("sugar-ai")
@@ -125,16 +125,39 @@ class RAGAgent:
     def run(self, question: str) -> str:
         """Process a question through the RAG pipeline."""
         doc_result, _ = self.get_relevant_document(question)
-        if doc_result:
-            prompt = self.prompt_template.format(
-                question=question,
-                context=doc_result.page_content
-            )
-        else:
-            prompt = self.prompt_template.format(
-                question=question,
-                context="No relevant documentation found."
-            )
+        retrieved_context = (
+            doc_result.page_content
+            if doc_result
+            else "No relevant documentation found."
+        )
+
+        # Reserve output space and account for the question/template before
+        # inserting retrieved text. The provider performs a final whole-prompt
+        # check, but budgeting retrieval here prevents relevant context from
+        # consuming the entire input window first.
+        empty_context_prompt = self.prompt_template.format(
+            question=question,
+            context="",
+        )
+        default_output = GenerationParams().max_new_tokens
+        context_budget = ContextBudget(
+            context_window=self.provider.get_context_window(),
+            output_tokens=min(default_output, self.provider.get_context_window() - 1),
+        )
+        retrieval_tokens = max(
+            1,
+            context_budget.input_tokens - self.provider.count_tokens(empty_context_prompt) - 4,
+        )
+        retrieved_context = fit_text(
+            retrieved_context,
+            ContextBudget(retrieval_tokens, 0),
+            counter=self.provider.count_tokens,
+        )
+
+        prompt = self.prompt_template.format(
+            question=question,
+            context=retrieved_context,
+        )
 
         first_response = self.provider.generate(prompt)
 

--- a/app/context.py
+++ b/app/context.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Provider-neutral context-window budgeting helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+
+# A conservative approximation used when a provider does not expose a tokenizer.
+def estimate_tokens(text: str) -> int:
+    """Estimate token count from text without a model-specific tokenizer."""
+    if not text:
+        return 0
+    return max(1, (len(text) + 3) // 4)
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    """The input/output allocation for one model invocation."""
+
+    context_window: int
+    output_tokens: int
+
+    @property
+    def input_tokens(self) -> int:
+        return max(1, self.context_window - self.output_tokens)
+
+
+def _message_tokens(message: dict, counter: Callable[[str], int]) -> int:
+    return counter(str(message.get("content", ""))) + 4
+
+
+def _compact(message: dict, max_tokens: int, counter: Callable[[str], int]) -> dict:
+    """Keep a bounded excerpt of a message while preserving its role."""
+    content = str(message.get("content", ""))
+    suffix = "\n[…truncated…]"
+    if counter(content) <= max_tokens:
+        return {"role": message.get("role", "user"), "content": content}
+    if counter(suffix) > max_tokens:
+        return {"role": message.get("role", "user"), "content": ""}
+
+    # Binary search over characters, but validate every candidate with the
+    # supplied counter. This works with both the fallback estimator and an
+    # exact provider tokenizer; no chars-per-token assumption is required.
+    low, high = 0, len(content)
+    best = suffix
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = content[:midpoint].rstrip() + suffix
+        if counter(candidate) <= max_tokens:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return {
+        "role": message.get("role", "user"),
+        "content": best,
+    }
+
+
+def fit_messages(
+    messages: Iterable[dict],
+    budget: ContextBudget,
+    counter: Callable[[str], int] = estimate_tokens,
+) -> list[dict]:
+    """Fit chat messages into a budget, compressing older turns first.
+
+    System instructions and the most recent turns are retained. Older turns are
+    represented by a short deterministic summary, making the behavior portable
+    across providers and safe when no summarization model is available.
+    """
+    source = [
+        {"role": item.get("role", "user"), "content": str(item.get("content", ""))}
+        for item in messages
+    ]
+    if not source:
+        return []
+
+    system = [item for item in source if item["role"] == "system"]
+    turns = [item for item in source if item["role"] != "system"]
+    system_tokens = sum(_message_tokens(item, counter) for item in system)
+    available = max(1, budget.input_tokens - system_tokens)
+
+    kept: list[dict] = []
+    used = 0
+    for item in reversed(turns):
+        cost = _message_tokens(item, counter)
+        if used + cost > available:
+            break
+        kept.append(item)
+        used += cost
+    kept.reverse()
+
+    dropped = turns[: len(turns) - len(kept)]
+    if dropped:
+        summary_lines = []
+        remaining = max(1, available - used - 12)
+        for item in dropped:
+            prefix = f"{item['role']}: "
+            excerpt_budget = max(1, remaining // max(1, len(dropped)))
+            excerpt = _compact({"role": "user", "content": prefix + item["content"]}, excerpt_budget, counter)["content"]
+            summary_lines.append(excerpt)
+        summary = {
+            "role": "system",
+            "content": "Earlier conversation (compressed):\n" + "\n".join(summary_lines),
+        }
+        system = system + [summary]
+
+    result = system + kept
+    # A summary has framing overhead too; repeatedly compact system content
+    # until the same accounting used above proves it fits.
+    while sum(_message_tokens(item, counter) for item in result) > budget.input_tokens:
+        candidates = [
+            (index, counter(item["content"]))
+            for index, item in enumerate(result)
+            if item["role"] == "system" and item["content"]
+        ]
+        if not candidates:
+            # The latest turn is more useful than an old one when the budget is
+            # exceptionally small, so discard the oldest non-system turn.
+            if len(result) > 1:
+                result.pop(0)
+            else:
+                break
+            continue
+        index, current = max(candidates, key=lambda pair: pair[1])
+        compacted = _compact(result[index], max(1, current - 4), counter)
+        if compacted["content"] == result[index]["content"]:
+            # The truncation marker is larger than the remaining budget.
+            result[index] = {"role": "system", "content": ""}
+        else:
+            result[index] = compacted
+    return result
+
+
+def fit_text(text: str, budget: ContextBudget, counter: Callable[[str], int] = estimate_tokens) -> str:
+    """Trim a plain prompt to the input side of a context budget."""
+    if counter(text) <= budget.input_tokens:
+        return text
+    return _compact({"role": "user", "content": text}, budget.input_tokens, counter)["content"]

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -17,8 +17,11 @@
 """Base provider interface for Sugar-AI."""
 import httpx
 import logging
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, replace
 from typing import Optional
+
+from app.context import ContextBudget, estimate_tokens, fit_messages, fit_text
 
 logger = logging.getLogger("sugar-ai")
 
@@ -73,14 +76,60 @@ class BaseProvider:
             self.base_url,
         )
 
+    def get_context_window(self) -> int:
+        """Return the model context window, with a portable safe default."""
+        return max(1, int(os.getenv("AI_CONTEXT_WINDOW", "4096")))
+
+    def get_model_metadata(self) -> dict:
+        """Expose model limits to the runtime and frontend."""
+        max_output = min(1024, max(1, self.get_context_window() - 1))
+        return {
+            "model": self.get_model_name(),
+            "provider": type(self).__name__,
+            "context_window": self.get_context_window(),
+            "max_output_tokens": max_output,
+            "safe_input_tokens": self.get_context_window() - max_output,
+        }
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens for budgeting; providers may use an exact tokenizer."""
+        return estimate_tokens(text)
+
+    def prepare_messages(self, messages: list[dict], params: GenerationParams) -> list[dict]:
+        """Compress older turns so input plus output fits the model window."""
+        budget = ContextBudget(
+            context_window=self.get_context_window(),
+            output_tokens=min(params.max_new_tokens, self.get_context_window() - 1),
+        )
+        return fit_messages(messages, budget, counter=self.count_tokens)
+
+    def bound_params(self, params: GenerationParams) -> GenerationParams:
+        """Clamp output tokens so input and output cannot exceed the window."""
+        return replace(
+            params,
+            max_new_tokens=min(params.max_new_tokens, self.get_context_window() - 1),
+        )
+
+    def prepare_prompt(self, prompt: str, params: GenerationParams) -> str:
+        """Trim a plain prompt so an output reservation is always preserved."""
+        budget = ContextBudget(
+            context_window=self.get_context_window(),
+            output_tokens=min(params.max_new_tokens, self.get_context_window() - 1),
+        )
+        return fit_text(prompt, budget, counter=self.count_tokens)
+
     def generate(self, prompt: str, params: Optional[GenerationParams] = None) -> str:
         """Generate text from a plain prompt by wrapping it as a user message."""
+        params = params or GenerationParams()
+        prompt = self.prepare_prompt(prompt, params)
         return self.chat([{"role": "user", "content": prompt}], params)
 
     def chat(self, messages: list[dict], params: Optional[GenerationParams] = None) -> str:
         """Generate a response from chat messages via /chat/completions."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        messages = self.prepare_messages(messages, params)
 
         payload = {
             "model": self.model_name,

--- a/app/providers/gemini.py
+++ b/app/providers/gemini.py
@@ -65,6 +65,8 @@ class GeminiProvider(BaseProvider):
         """Generate a response from chat messages."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        messages = self.prepare_messages(messages, params)
 
         contents, system_instruction = self._to_gemini_contents(messages)
 

--- a/app/providers/huggingface.py
+++ b/app/providers/huggingface.py
@@ -25,6 +25,11 @@ from app.context import estimate_tokens
 
 logger = logging.getLogger("sugar-ai")
 
+# Hugging Face tokenizers report an enormous placeholder value (commonly
+# 1e30-scale) when no real model_max_length was configured. Values below this
+# threshold are treated as real, usable context limits.
+_UNSET_MODEL_MAX_LENGTH_THRESHOLD = 1_000_000
+
 
 class HuggingFaceProvider(BaseProvider):
     """Provider running HuggingFace models locally via transformers."""
@@ -71,7 +76,10 @@ class HuggingFaceProvider(BaseProvider):
 
         model_limit = getattr(self._pipeline.tokenizer, "model_max_length", None)
         self._context_window = (
-            int(model_limit) if isinstance(model_limit, int) and model_limit < 1_000_000 else None
+            int(model_limit)
+            if isinstance(model_limit, int)
+            and 0 < model_limit < _UNSET_MODEL_MAX_LENGTH_THRESHOLD
+            else None
         )
 
         logger.info("HuggingFaceProvider loaded model: %s (quantized=%s, device=%s)",

--- a/app/providers/huggingface.py
+++ b/app/providers/huggingface.py
@@ -21,6 +21,7 @@ import logging
 from typing import Optional
 
 from app.providers.base import BaseProvider, GenerationParams
+from app.context import estimate_tokens
 
 logger = logging.getLogger("sugar-ai")
 
@@ -68,13 +69,40 @@ class HuggingFaceProvider(BaseProvider):
                 device=device,
             )
 
+        model_limit = getattr(self._pipeline.tokenizer, "model_max_length", None)
+        self._context_window = (
+            int(model_limit) if isinstance(model_limit, int) and model_limit < 1_000_000 else None
+        )
+
         logger.info("HuggingFaceProvider loaded model: %s (quantized=%s, device=%s)",
                     model_name, use_quant, device)
+
+    def get_context_window(self) -> int:
+        """Prefer the tokenizer's advertised model limit when it is reliable."""
+        return self._context_window or super().get_context_window()
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens with the loaded model tokenizer when possible."""
+        try:
+            encoded = self._pipeline.tokenizer(
+                text,
+                add_special_tokens=False,
+                truncation=False,
+            )
+            input_ids = encoded["input_ids"]
+            return len(input_ids[0]) if input_ids and isinstance(input_ids[0], list) else len(input_ids)
+        except Exception as exc:
+            # Some lightweight test doubles and unusual tokenizers do not
+            # support the full call signature; retain a safe fallback.
+            logger.debug("Hugging Face tokenizer failed during budgeting: %s", exc)
+            return estimate_tokens(text)
 
     def generate(self, prompt: str, params: Optional[GenerationParams] = None) -> str:
         """Generate text from a plain string prompt."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        prompt = self.prepare_prompt(prompt, params)
 
         response = self._pipeline(
             prompt,
@@ -98,6 +126,8 @@ class HuggingFaceProvider(BaseProvider):
         """Generate response from chat messages."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        messages = self.prepare_messages(messages, params)
 
         normalized = self._normalize_chat_messages(messages)
         full_prompt = self._pipeline.tokenizer.apply_chat_template(
@@ -140,11 +170,11 @@ class HuggingFaceProvider(BaseProvider):
 
     def _normalize_chat_messages(self, messages: list[dict]) -> list[dict]:
         """Normalize messages for model-specific requirements."""
-        system_content = ""
-        for msg in messages:
-            if msg.get("role") == "system" and msg.get("content"):
-                system_content = msg["content"]
-                break
+        system_content = "\n\n".join(
+            msg["content"]
+            for msg in messages
+            if msg.get("role") == "system" and msg.get("content")
+        )
 
         non_system_messages = [msg for msg in messages if msg.get("role") != "system"]
         if not non_system_messages:

--- a/app/providers/ollama.py
+++ b/app/providers/ollama.py
@@ -51,6 +51,8 @@ class OllamaProvider(BaseProvider):
         """Generate text from a plain string prompt."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        prompt = self.prepare_prompt(prompt, params)
 
         payload = {
             "model": self.model_name,
@@ -72,6 +74,8 @@ class OllamaProvider(BaseProvider):
         """Generate response from chat messages."""
         if params is None:
             params = GenerationParams()
+        params = self.bound_params(params)
+        messages = self.prepare_messages(messages, params)
 
         payload = {
             "model": self.model_name,

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -2,17 +2,12 @@
 API routes for Sugar-AI.
 """
 from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
-from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 import time
 import logging
-import os
-import json
 from datetime import datetime
 from typing import Dict, Optional, List
 
-from app.database import get_db, APIKey
-from app.ai import RAGAgent
 from app.providers.base import GenerationParams
 from app.config import settings
 
@@ -359,6 +354,7 @@ async def health_check():
 
     try:
         model_name = agent.provider.get_model_name()
+        metadata = agent.provider.get_model_metadata()
         is_healthy = agent.provider.health_check()
 
         if is_healthy:
@@ -366,12 +362,14 @@ async def health_check():
                 "status": "healthy",
                 "provider": type(agent.provider).__name__,
                 "model": model_name,
+                "context": metadata,
             }
         else:
             return {
                 "status": "unhealthy",
                 "provider": type(agent.provider).__name__,
                 "model": model_name,
+                "context": metadata,
                 "detail": "Health check failed",
             }
     except Exception as e:
@@ -380,3 +378,11 @@ async def health_check():
             "status": "error",
             "detail": str(e),
         }
+
+
+@router.get("/model-metadata")
+async def model_metadata():
+    """Return model limits needed for client-side input guardrails."""
+    if agent is None:
+        raise HTTPException(status_code=503, detail="Agent not initialized")
+    return agent.provider.get_model_metadata()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+pytest>=8.0
+fastapi
+sqlalchemy
+authlib
+itsdangerous
+jinja2
+python-multipart
+pydantic-settings
+httpx

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -9,6 +9,19 @@ document.addEventListener('DOMContentLoaded', function() {
     const apiKeyField = document.getElementById('api-key-field');
     const toggleApiKeyBtn = document.getElementById('toggle-api-key');
     const copyApiKeyBtn = document.getElementById('copy-api-key');
+    const contextWarning = document.getElementById('context-warning');
+    let safeInputTokens = 3072;
+
+    // The backend owns the active model limit. The client only estimates tokens
+    // for an early warning; the provider performs the authoritative fitting.
+    fetch('/model-metadata', { credentials: 'same-origin' })
+        .then(response => response.ok ? response.json() : null)
+        .then(metadata => {
+            if (metadata && metadata.safe_input_tokens) {
+                safeInputTokens = metadata.safe_input_tokens;
+            }
+        })
+        .catch(() => {});
     
     // New elements for endpoint selection
     const endpointRadios = document.querySelectorAll('input[name="endpoint-choice"]');
@@ -148,6 +161,13 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // send a message to the API
     async function sendMessage(message) {
+        const estimatedTokens = Math.ceil(message.length / 4);
+        if (contextWarning && estimatedTokens > safeInputTokens) {
+            contextWarning.textContent = `This message is about ${estimatedTokens} tokens; the model input budget is ${safeInputTokens}. It will be shortened automatically.`;
+            contextWarning.style.display = 'block';
+        } else if (contextWarning) {
+            contextWarning.style.display = 'none';
+        }
         addUserMessage(message);
         
         const typingIndicator = showTypingIndicator();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -72,6 +72,7 @@
                         <input type="text" class="chat-input" id="chat-input" placeholder="Type your question...">
                         <button class="chat-submit" id="chat-submit">Send</button>
                     </div>
+                    <p id="context-warning" role="status" style="display: none; color: #b45309; font-size: 0.9em; margin-top: 8px;"></p>
                 </div>
                 
                 <div style="margin-top: 20px;">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test-only stubs for optional ML dependencies."""
+import sys
+import types
+from types import SimpleNamespace
+
+
+if "torch" not in sys.modules:
+    torch = types.ModuleType("torch")
+    torch.cuda = SimpleNamespace(is_available=lambda: False)
+    torch.float16 = object()
+    torch.float32 = object()
+    sys.modules["torch"] = torch
+
+
+if "transformers" not in sys.modules:
+    transformers = types.ModuleType("transformers")
+    transformers.pipeline = object
+    transformers.AutoModelForCausalLM = object
+    transformers.AutoTokenizer = object
+    transformers.BitsAndBytesConfig = object
+    sys.modules["transformers"] = transformers

--- a/tests/test_api_metadata.py
+++ b/tests/test_api_metadata.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from app import create_app
+from app.routes import api
+
+
+METADATA = {
+    "model": "test-model",
+    "provider": "TestProvider",
+    "context_window": 4096,
+    "max_output_tokens": 1024,
+    "safe_input_tokens": 3072,
+}
+
+
+def _client_with_mock_agent(monkeypatch, metadata=METADATA, healthy=True):
+    provider = MagicMock()
+    provider.get_model_metadata.return_value = metadata
+    provider.get_model_name.return_value = "test-model"
+    provider.health_check.return_value = healthy
+    monkeypatch.setattr(api, "agent", SimpleNamespace(provider=provider))
+    return TestClient(create_app())
+
+
+def test_model_metadata_endpoint_returns_provider_limits(monkeypatch):
+    client = _client_with_mock_agent(monkeypatch)
+
+    response = client.get("/model-metadata")
+
+    assert response.status_code == 200
+    assert response.json() == METADATA
+
+
+def test_model_metadata_endpoint_returns_503_when_agent_missing(monkeypatch):
+    monkeypatch.setattr(api, "agent", None)
+    client = TestClient(create_app())
+
+    response = client.get("/model-metadata")
+
+    assert response.status_code == 503
+
+
+def test_health_healthy_response_includes_context_metadata(monkeypatch):
+    client = _client_with_mock_agent(monkeypatch, healthy=True)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["context"] == METADATA
+
+
+def test_health_unhealthy_response_includes_context_metadata(monkeypatch):
+    client = _client_with_mock_agent(monkeypatch, healthy=False)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["context"] == METADATA

--- a/tests/test_context_management.py
+++ b/tests/test_context_management.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from app.context import ContextBudget, estimate_tokens, fit_messages, fit_text
+from app.providers.base import BaseProvider, GenerationParams
+from app.providers.huggingface import HuggingFaceProvider
+
+
+class DummyProvider(BaseProvider):
+    def __init__(self):
+        # Avoid network setup: these tests exercise the provider seam only.
+        self.model_name = "dummy"
+        self.base_url = "http://example.test"
+
+    def get_context_window(self):
+        return 64
+
+
+def test_estimator_is_stable_and_nonzero_for_nonempty_text():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens("a" * 5) == 2
+
+
+def test_fit_messages_preserves_system_and_latest_turns():
+    messages = [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": "old " * 30},
+        {"role": "assistant", "content": "old answer " * 20},
+        {"role": "user", "content": "latest question"},
+    ]
+    result = fit_messages(messages, ContextBudget(64, 16))
+    assert result[0]["role"] == "system"
+    assert result[-1]["content"] == "latest question"
+    assert any("compressed" in item["content"] for item in result if item["role"] == "system")
+    assert sum(estimate_tokens(item["content"]) + 4 for item in result) <= 48
+
+
+def test_fit_text_reserves_requested_output_budget():
+    result = fit_text("word " * 100, ContextBudget(32, 8))
+    assert estimate_tokens(result) <= 24
+    assert "truncated" in result
+
+
+def test_fit_text_uses_custom_counter_without_character_ratio_assumption():
+    # Deliberately use a non-4-character tokenizer to catch accidental coupling
+    # between character slicing and token accounting.
+    counter = lambda text: len(text.split())
+    result = fit_text("one two three four five six", ContextBudget(5, 2), counter)
+    assert counter(result) <= 3
+    assert result.endswith("[…truncated…]")
+
+
+def test_provider_metadata_and_output_are_bounded(monkeypatch):
+    provider = DummyProvider()
+    monkeypatch.setenv("AI_CONTEXT_WINDOW", "999")
+    # DummyProvider intentionally advertises 64, proving provider-specific limits win.
+    metadata = provider.get_model_metadata()
+    assert metadata == {
+        "model": "dummy",
+        "provider": "DummyProvider",
+        "context_window": 64,
+        "max_output_tokens": 63,
+        "safe_input_tokens": 1,
+    }
+    params = provider.bound_params(GenerationParams(max_new_tokens=1000))
+    assert params.max_new_tokens == 63
+
+
+def test_prepare_messages_never_uses_more_than_input_budget():
+    provider = DummyProvider()
+    messages = [{"role": "user", "content": "long " * 100}]
+    prepared = provider.prepare_messages(messages, GenerationParams(max_new_tokens=16))
+    assert sum(estimate_tokens(item["content"]) + 4 for item in prepared) <= 48
+
+
+def test_huggingface_count_tokens_uses_tokenizer_and_falls_back_safely():
+    provider = object.__new__(HuggingFaceProvider)
+
+    class Tokenizer:
+        def __call__(self, text, **kwargs):
+            return {"input_ids": [1, 2, 3]}
+
+    provider._pipeline = type("Pipeline", (), {"tokenizer": Tokenizer()})()
+    assert provider.count_tokens("any text") == 3
+
+    class BrokenTokenizer:
+        def __call__(self, text, **kwargs):
+            raise RuntimeError("tokenizer unavailable")
+
+    provider._pipeline.tokenizer = BrokenTokenizer()
+    assert provider.count_tokens("abcd") == estimate_tokens("abcd")
+
+
+def test_huggingface_normalization_preserves_compressed_system_history():
+    provider = object.__new__(HuggingFaceProvider)
+    provider.model_name = "test-model"
+    normalized = provider._normalize_chat_messages([
+        {"role": "system", "content": "Be helpful."},
+        {"role": "system", "content": "Earlier conversation (compressed): old turn"},
+        {"role": "user", "content": "latest question"},
+    ])
+    assert normalized[0]["content"] == (
+        "Be helpful.\n\nEarlier conversation (compressed): old turn\n\nlatest question"
+    )

--- a/tests/test_rag_budgeting.py
+++ b/tests/test_rag_budgeting.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2026 Sugar Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import types
+from types import SimpleNamespace
+
+# Keep this test lightweight while exercising RAGAgent.run end to end.
+community = types.ModuleType("langchain_community")
+vectorstores = types.ModuleType("langchain_community.vectorstores")
+loaders = types.ModuleType("langchain_community.document_loaders")
+vectorstores.FAISS = object
+loaders.PyMuPDFLoader = object
+loaders.TextLoader = object
+community.vectorstores = vectorstores
+community.document_loaders = loaders
+sys.modules["langchain_community"] = community
+sys.modules["langchain_community.vectorstores"] = vectorstores
+sys.modules["langchain_community.document_loaders"] = loaders
+
+huggingface = types.ModuleType("langchain_huggingface")
+huggingface.HuggingFaceEmbeddings = object
+sys.modules["langchain_huggingface"] = huggingface
+
+from app.ai import RAGAgent
+from app.context import estimate_tokens
+
+
+class FakeProvider:
+    def __init__(self):
+        self.prompts = []
+
+    def get_model_name(self):
+        return "fake"
+
+    def get_context_window(self):
+        return 128
+
+    def count_tokens(self, text):
+        return estimate_tokens(text)
+
+    def generate(self, prompt, params=None):
+        self.prompts.append(prompt)
+        return "Answer: bounded response"
+
+    def get_eos_token(self):
+        return None
+
+
+def test_rag_retrieved_context_is_budgeted_before_generation():
+    provider = FakeProvider()
+    agent = RAGAgent(provider)
+    agent.get_relevant_document = lambda question: (
+        SimpleNamespace(page_content="documentation " * 1000),
+        1.0,
+    )
+
+    agent.run("How does this work?")
+
+    assert len(provider.prompts) == 2
+    assert len(provider.prompts[0]) < 2500


### PR DESCRIPTION
Fixes #120

## Summary
Adds provider-aware context-window budgeting so long prompts and chat
histories can no longer overflow a model's context window, and closes
the gap where the default Hugging Face path relied only on `truncation=True`
with no explicit budget accounting.

## Changes
- `app/context.py` (new): provider-neutral token estimation, a
  `ContextBudget` allocation, and `fit_messages`/`fit_text` helpers that
  compress older chat turns into a deterministic summary rather than
  silently dropping them.
- `app/providers/base.py`: adds `count_tokens()`, `bound_params()`,
  `prepare_prompt()`, `prepare_messages()` on `BaseProvider`, wired
  polymorphically so any subclass override is picked up automatically.
- `app/providers/huggingface.py`: reads the loaded tokenizer's
  `model_max_length` (guarded against the unset-sentinel value), overrides
  `count_tokens()` with the real tokenizer, and routes `generate()`/`chat()`
  through the shared budgeting before calling the pipeline. Also fixes an
  existing bug in `_normalize_chat_messages()` that kept only the first
  system-role message — needed once compression can add a second one.
- `app/providers/ollama.py`, `app/providers/gemini.py`: route `generate()`/
  `chat()` through the same shared budgeting.
- `app/ai.py`: `RAGAgent.run()` reserves output space and trims retrieved
  RAG context using the active provider's exact token counter before
  formatting the prompt.
- `app/routes/api.py`: adds `GET /model-metadata` and includes the same
  metadata under `/health`.
- `static/js/dashboard.js` / `templates/dashboard.html`: the dashboard
  reads `/model-metadata` and shows a warning when an input is likely to
  exceed the safe budget. Backend remains authoritative.
- `tests/`: new test suite (`test_context_management.py`,
  `test_rag_budgeting.py`, `conftest.py`) with lightweight stubs so the
  suite never requires installing torch/transformers/langchain.
- `requirements-test.txt`, `.github/workflows/tests.yml`: lightweight CI
  so the test suite actually runs on every push/PR.

## Testing
Ran the full suite in a clean virtual environment with only
`requirements-test.txt` installed (no ML dependencies):

Also ran `pyflakes` over every changed file with no warnings.

## Related work
This overlaps with #131 (currently open), which addresses `max_new_tokens`
and basic chat budgeting on a narrower scope, and with #168, another open
PR against this same issue. This implementation additionally covers the
default Hugging Face path specifically, exact tokenizer counting, RAG
context budgeting, and frontend metadata. Flagging both so a maintainer
can decide how to reconcile the three rather than merging them independently.