### PR TITLE
fix: restore approved database API keys on startup

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -17,6 +17,7 @@ from starlette.responses import RedirectResponse
 from dotenv import load_dotenv
 
 from app.database import APIKey, get_db
+from app.config import settings
 
 # load environment variables
 load_dotenv()
@@ -142,3 +143,23 @@ def sync_env_keys_to_db(db: Session):
     except Exception as e:
         db.rollback()
         logger.error(f"Error syncing keys: {e}")
+
+
+def load_approved_keys_from_db(db: Session):
+    """Load approved, active database keys into the runtime key mapping."""
+    try:
+        approved_keys = db.query(APIKey).filter(
+            APIKey.approved.is_(True),
+            APIKey.is_active.is_(True),
+        ).all()
+
+        # The database is authoritative after environment keys have been synced.
+        # Rebuilding the mapping also removes keys revoked since the last run.
+        settings.API_KEYS.clear()
+        for key in approved_keys:
+            settings.API_KEYS[key.key] = {
+                "name": key.name,
+                "can_change_model": key.can_change_model,
+            }
+    except Exception as e:
+        logger.error(f"Error loading approved keys from database: {e}")

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from app import create_app
 from app.ai import RAGAgent
 from app.providers import create_provider
 from app.database import get_db
-from app.auth import sync_env_keys_to_db
+from app.auth import load_approved_keys_from_db, sync_env_keys_to_db
 from app.config import settings
 from app.routes import api
 
@@ -41,6 +41,7 @@ async def startup_event():
     """Initialize data on app startup"""
     db = next(get_db())
     sync_env_keys_to_db(db)
+    load_approved_keys_from_db(db)
     # Determine model name: AI_MODEL takes priority, then DEV/PROD fallback
     if settings.AI_MODEL:
         active_model = settings.AI_MODEL

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,129 @@
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import database
+from app.auth import load_approved_keys_from_db
+from app.config import settings
+
+
+class StubAgent:
+    def __init__(self):
+        self.provider = self
+
+    def generate(self, question):
+        return f"answer: {question}"
+
+
+# Importing the API router normally imports the heavyweight RAG implementation.
+# The endpoint test only exercises authentication and therefore uses a stub.
+stub_ai = types.ModuleType("app.ai")
+stub_ai.RAGAgent = object
+sys.modules.setdefault("app.ai", stub_ai)
+
+from app.routes import api  # noqa: E402
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    database.Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_load_approved_active_keys_from_database():
+    session = make_session()
+    session.add_all([
+        database.APIKey(
+            key="oauth-key",
+            name="OAuth User",
+            email="oauth@example.com",
+            approved=True,
+            is_active=True,
+            can_change_model=False,
+        ),
+        database.APIKey(
+            key="pending-key",
+            name="Pending User",
+            email="pending@example.com",
+            approved=False,
+            is_active=False,
+        ),
+        database.APIKey(
+            key="revoked-key",
+            name="Revoked User",
+            email="revoked@example.com",
+            approved=True,
+            is_active=False,
+        ),
+        database.APIKey(
+            key="revoked-env-key",
+            name="Revoked Environment User",
+            email="revoked-env@example.com",
+            approved=False,
+            is_active=True,
+        ),
+    ])
+    session.commit()
+
+    settings.API_KEYS.clear()
+    settings.API_KEYS["env-key"] = {
+        "name": "Environment User",
+        "can_change_model": True,
+    }
+    settings.API_KEYS["revoked-env-key"] = {
+        "name": "Revoked Environment User",
+        "can_change_model": False,
+    }
+
+    load_approved_keys_from_db(session)
+
+    assert settings.API_KEYS == {
+        "oauth-key": {
+            "name": "OAuth User",
+            "can_change_model": False,
+        },
+    }
+    assert "revoked-env-key" not in settings.API_KEYS
+
+    session.close()
+    settings.API_KEYS.clear()
+
+
+def test_restored_key_authenticates_against_api_endpoint():
+    session = make_session()
+    session.add(database.APIKey(
+        key="oauth-key",
+        name="OAuth User",
+        email="oauth@example.com",
+        approved=True,
+        is_active=True,
+    ))
+    session.commit()
+
+    # Simulate a fresh process: the database survives, but the runtime map is
+    # empty until startup restores approved keys.
+    settings.API_KEYS.clear()
+    load_approved_keys_from_db(session)
+    api.user_quotas.clear()
+    api.agent = StubAgent()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    response = TestClient(app).post(
+        "/ask-llm",
+        params={"question": "What is Python?"},
+        headers={"X-API-Key": "oauth-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["user"] == "OAuth User"
+    assert response.json()["answer"] == "answer: What is Python?"
+
+    session.close()
+    settings.API_KEYS.clear()
+    api.user_quotas.clear()
+    api.agent = None


### PR DESCRIPTION
OAuth-issued API keys are stored in the database but were never reloaded into the in-memory settings.API_KEYS map on startup, so users lost access after every restart. Reload approved and active keys from the database after environment migration, rebuilding the map so keys revoked in the database do not silently regain access on restart.

Fixes #102